### PR TITLE
pg gems and python modules need postgres libs to build

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,7 @@ node.override['nodejs']['binary']['checksum']['linux_x64'] = 'f0a53527f52dbcab'\
 
 # rvm package depends
 %w(sqlite-devel libyaml-devel readline-devel zlib-devel libffi-devel
-   openssl-devel automake libtool mariadb-devel ImageMagick-devel 
+   openssl-devel automake libtool mariadb-devel ImageMagick-devel
    postgresql-devel).each do |p|
   package p
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,8 @@ node.override['nodejs']['binary']['checksum']['linux_x64'] = 'f0a53527f52dbcab'\
 
 # rvm package depends
 %w(sqlite-devel libyaml-devel readline-devel zlib-devel libffi-devel
-   openssl-devel automake libtool mariadb-devel ImageMagick-devel).each do |p|
+   openssl-devel automake libtool mariadb-devel ImageMagick-devel 
+   postgresql-devel).each do |p|
   package p
 end
 

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -61,9 +61,4 @@ describe 'osl-app::app1' do
         expect(chef_run).to create_systemd_service(s)
       end
     end
-
-    describe package('postgresql-devel') do
-      it { should be_installed }
-    end
-  end
 end

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -61,5 +61,9 @@ describe 'osl-app::app1' do
         expect(chef_run).to create_systemd_service(s)
       end
     end
+
+    describe package('postgresql-devel') do
+      it { should be_installed }
+    end
   end
 end

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -61,4 +61,5 @@ describe 'osl-app::app1' do
         expect(chef_run).to create_systemd_service(s)
       end
     end
+  end
 end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -5,7 +5,7 @@ set :backend, :exec
 set :path, '/usr/local/bin:$PATH'
 
 %w(sqlite-devel libyaml-devel readline-devel zlib-devel libffi-devel
-   openssl-devel automake libtool python git).each do |p|
+   openssl-devel automake libtool python git postgresql-devel).each do |p|
   describe package(p) do
     it { should be_installed }
   end


### PR DESCRIPTION
Adding postgresql dev libs for building pg gems and python modules. Kitchen converge errors on this repo, so not tested.