### PR TITLE
Add timesync services to app2.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,8 @@ suites:
         - formsender-production
         - iam-staging
         - iam-production
+        - timesync-production
+        - timesync-staging
     run_list:
       - recipe[sudo]
       - recipe[user::data_bag]

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -19,7 +19,8 @@
 include_recipe 'osl-app::default'
 
 node.normal['users'] = %w(formsender-production formsender-staging
-                          iam-staging iam-production)
+                          iam-staging iam-production
+                          timesync-staging timesync-production)
 
 #### Sudo Privs ####
 
@@ -116,5 +117,37 @@ systemd_service 'iam-production' do
     pid_file '/home/iam-production/pids/unicorn.pid'
     exec_start '/home/iam-production/.rvm/bin/rvm 2.3.0 do bundle exec '\
       'unicorn -l 8084 -c config/unicorn.rb -E deployment -D'
+  end
+end
+
+systemd_service 'timesync-staging' do
+  description 'Time tracker'
+  after %w(network.target)
+  install do
+    wanted_by 'multi-user.target'
+  end
+  service do
+    type 'forking'
+    environment_file '/home/timesync-staging/timesync.env'
+    user 'timesync-staging'
+    working_directory '/home/timesync-staging/timesync'
+    pid_file '/home/timesync-staging/pids/timesync.pid'
+    exec_start 'node src/app.js'
+  end
+end
+
+systemd_service 'timesync-production' do
+  description 'Time tracker'
+  after %w(network.target)
+  install do
+    wanted_by 'multi-user.target'
+  end
+  service do
+    type 'forking'
+    environment_file '/home/timesync-production/timesync.env'
+    user 'timesync-production'
+    working_directory '/home/timesync-production/timesync'
+    pid_file '/home/timesync-production/pids/timesync.pid'
+    exec_start 'node src/app.js'
   end
 end

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -48,6 +48,18 @@ sudo 'iam-production' do
   nopasswd true
 end
 
+sudo 'timesync-production' do
+  user 'timesync-production'
+  commands sudo_commands('timesync-production')
+  nopasswd true
+end
+
+sudo 'timesync-staging' do
+  user 'timesync-staging'
+  commands sudo_commands('timesync-staging')
+  nopasswd true
+end
+
 #### Systemd Services ####
 
 systemd_service 'formsender-staging-gunicorn' do

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -139,12 +139,11 @@ systemd_service 'timesync-staging' do
     wanted_by 'multi-user.target'
   end
   service do
-    type 'forking'
     environment_file '/home/timesync-staging/timesync.env'
     user 'timesync-staging'
     working_directory '/home/timesync-staging/timesync'
     pid_file '/home/timesync-staging/pids/timesync.pid'
-    exec_start 'node src/app.js'
+    exec_start '/usr/local/bin/node /home/timesync-staging/timesync/src/app.js'
   end
 end
 
@@ -155,11 +154,10 @@ systemd_service 'timesync-production' do
     wanted_by 'multi-user.target'
   end
   service do
-    type 'forking'
     environment_file '/home/timesync-production/timesync.env'
     user 'timesync-production'
     working_directory '/home/timesync-production/timesync'
     pid_file '/home/timesync-production/pids/timesync.pid'
-    exec_start 'node src/app.js'
+    exec_start '/usr/local/bin/node /home/timesync-production/timesync/src/app.js'
   end
 end

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -158,6 +158,7 @@ systemd_service 'timesync-production' do
     user 'timesync-production'
     working_directory '/home/timesync-production/timesync'
     pid_file '/home/timesync-production/pids/timesync.pid'
-    exec_start '/usr/local/bin/node /home/timesync-production/timesync/src/app.js'
+    exec_start '/usr/local/bin/node ' \
+      '/home/timesync-production/timesync/src/app.js'
   end
 end

--- a/spec/app2_spec.rb
+++ b/spec/app2_spec.rb
@@ -85,7 +85,8 @@ describe 'osl-app::app2' do
   end
 
   %w(formsender-staging-gunicorn formsender-production-gunicorn
-     iam-staging iam-production timesync-staging timesync-production).each do |s|
+     iam-staging iam-production
+     timesync-staging timesync-production).each do |s|
     it "should create system service #{s}" do
       expect(chef_run).to create_systemd_service(s)
     end

--- a/spec/app2_spec.rb
+++ b/spec/app2_spec.rb
@@ -85,7 +85,7 @@ describe 'osl-app::app2' do
   end
 
   %w(formsender-staging-gunicorn formsender-production-gunicorn
-     iam-staging iam-production).each do |s|
+     iam-staging iam-production timesync-staging timesync-production).each do |s|
     it "should create system service #{s}" do
       expect(chef_run).to create_systemd_service(s)
     end

--- a/spec/app2_spec.rb
+++ b/spec/app2_spec.rb
@@ -58,6 +58,32 @@ describe 'osl-app::app2' do
     )
   end
 
+  it 'should create systemctl privs for timesync-production' do
+    expect(chef_run).to install_sudo('timesync-production').with(
+      commands: ['/usr/bin/systemctl enable timesync-production',
+                 '/usr/bin/systemctl disable timesync-production',
+                 '/usr/bin/systemctl stop timesync-production',
+                 '/usr/bin/systemctl start timesync-production',
+                 '/usr/bin/systemctl status timesync-production',
+                 '/usr/bin/systemctl reload timesync-production',
+                 '/usr/bin/systemctl restart timesync-production'],
+      nopasswd: true
+    )
+  end
+
+  it 'should create systemctl privs for timesync-staging' do
+    expect(chef_run).to install_sudo('timesync-staging').with(
+      commands: ['/usr/bin/systemctl enable timesync-staging',
+                 '/usr/bin/systemctl disable timesync-staging',
+                 '/usr/bin/systemctl stop timesync-staging',
+                 '/usr/bin/systemctl start timesync-staging',
+                 '/usr/bin/systemctl status timesync-staging',
+                 '/usr/bin/systemctl reload timesync-staging',
+                 '/usr/bin/systemctl restart timesync-staging'],
+      nopasswd: true
+    )
+  end
+
   %w(formsender-staging-gunicorn formsender-production-gunicorn
      iam-staging iam-production).each do |s|
     it "should create system service #{s}" do

--- a/test/integration/data_bags/users/timesync-production.json
+++ b/test/integration/data_bags/users/timesync-production.json
@@ -1,0 +1,5 @@
+{
+  "id": "timesync-production",
+  "username": "timesync-production",
+  "ssh_keygen": false
+}

--- a/test/integration/data_bags/users/timesync-staging.json
+++ b/test/integration/data_bags/users/timesync-staging.json
@@ -1,0 +1,5 @@
+{
+  "id": "timesync-staging",
+  "username": "timesync-staging",
+  "ssh_keygen": false
+}


### PR DESCRIPTION
The Chef component of migrating TimeSync-Node to app2. Works together with https://git.osuosl.org/osuosl-chef/data_bags/merge_requests/169 and https://git.osuosl.org/osuosl-chef/data_bags/merge_requests/170, and https://git.osuosl.org/osuosl/ansible_playbooks/merge_requests/11.