### PR TITLE
Add warning comment about updating NodeJS version.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,10 @@
 node.override['user']['home_dir_mode'] = '2750'
 node.default['poise-python']['provider'] = 'system'
 
+# WARNING!
+# If this gets updated, all NodeJS apps running will need to have their
+# node_modules directories completely removed and `npm install` run again to
+# update the modules to match the new Node version's ABI.
 node.override['nodejs']['version'] = '6.9.1'
 node.override['nodejs']['install_method'] = 'binary'
 node.override['nodejs']['binary']['checksum']['linux_x64'] = 'd4eb161e4715e1' \


### PR DESCRIPTION
After a timesync outage that occurred due to not following this advice, it is probably best to place this warning above the NodeJS version explicitly to prevent further issues.