### PR TITLE
Add staging and production users for fenestra.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,8 @@ suites:
     attributes:
       users:
         - test1-staging
+        - fenestra-staging
+        - fenestra-production
     run_list:
       - recipe[sudo]
       - recipe[user::data_bag]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
     - '**/Cheffile'
   Exclude:
     - 'metadata.rb'
+    - 'files/default/build_cookbook/test-fixture-recipe.rb'
 
 Metrics/BlockNesting:
   Max: 4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,6 @@ AllCops:
     - '**/Cheffile'
   Exclude:
     - 'metadata.rb'
-    - 'files/default/build_cookbook/test-fixture-recipe.rb'
 
 Metrics/BlockNesting:
   Max: 4

--- a/recipes/app1.rb
+++ b/recipes/app1.rb
@@ -171,4 +171,3 @@ systemd_service 'fenestra-production_service' do
     '8083 -c config/unicorn.rb -E deployment -D'
   end
 end
-

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -115,7 +115,7 @@ describe 'osl-app::app1' do
     )
   end
 
-  %w(fenestra-staging-unicorn fenestra-production-unicorn).each do |s|
+  %w(fenestra-staging_service fenestra-production_service).each do |s|
     it "should create system service #{s}" do
       expect(chef_run).to create_systemd_service(s)
     end

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -6,6 +6,10 @@ describe 'osl-app::app1' do
   end
   include_context 'common_stubs'
 
+  ###########################################################################
+  # OPENID
+  ###########################################################################
+
   before do
     stub_data_bag_item('osl-app', 'openid').and_return(
       secret_key_base: '7eef5c70ecb083192f46e601144f9d77c9b66061b634963a507'\
@@ -70,6 +74,50 @@ describe 'osl-app::app1' do
         su: "openid-#{type} openid-#{type}",
         rotate: 30
       )
+    end
+  end
+
+  ###########################################################################
+  # FENESTRA
+  ###########################################################################
+
+  before do
+    stub_data_bag_item('osl-app', 'fenestra').and_return(
+      secret_key_base: '7eef5c70ecb083192f46e601144f9d77c9b66061b634963a507'\
+        '0fb086ae78bc9353af2c6311edb168abbb9d0bd428f800a0b1713534cf4ad239e8d'\
+        '07fdd16c34'
+    )
+  end
+
+  it 'should create systemctl privs for fenestra-staging' do
+    expect(chef_run).to install_sudo('fenestra-staging').with(
+      commands: ['/usr/bin/systemctl enable fenestra-staging_service',
+                 '/usr/bin/systemctl disable fenestra-staging_service',
+                 '/usr/bin/systemctl stop fenestra-staging_service',
+                 '/usr/bin/systemctl start fenestra-staging_service',
+                 '/usr/bin/systemctl status fenestra-staging_service',
+                 '/usr/bin/systemctl reload fenestra-staging_service',
+                 '/usr/bin/systemctl restart fenestra-staging_service'],
+      nopasswd: true
+    )
+  end
+
+  it 'should create systemctl privs for fenestra-production' do
+    expect(chef_run).to install_sudo('fenestra-production').with(
+      commands: ['/usr/bin/systemctl enable fenestra-production_service',
+                 '/usr/bin/systemctl disable fenestra-production_service',
+                 '/usr/bin/systemctl stop fenestra-production_service',
+                 '/usr/bin/systemctl start fenestra-production_service',
+                 '/usr/bin/systemctl status fenestra-production_service',
+                 '/usr/bin/systemctl reload fenestra-production_service',
+                 '/usr/bin/systemctl restart fenestra-production_service'],
+      nopasswd: true
+    )
+  end
+
+  %w(fenestra-staging-unicorn fenestra-production-unicorn).each do |s|
+    it "should create system service #{s}" do
+      expect(chef_run).to create_systemd_service(s)
     end
   end
 end

--- a/test/integration/data_bags/users/fenestra-production.json
+++ b/test/integration/data_bags/users/fenestra-production.json
@@ -1,0 +1,5 @@
+{
+  "id": "fenestra-production",
+  "username": "fenestra-production",
+  "ssh_keygen": false
+}

--- a/test/integration/data_bags/users/fenestra-staging.json
+++ b/test/integration/data_bags/users/fenestra-staging.json
@@ -1,0 +1,5 @@
+{
+  "id": "fenestra-staging",
+  "username": "fenestra-staging",
+  "ssh_keygen": false
+}


### PR DESCRIPTION
In preparation for moving Fenestra to an Ansible deployment, create both a staging and production user for fenestra, including data bags.