### PR TITLE
Kennric/adjust streamwebs

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,5 +1,5 @@
 def sudo_commands(*args)
-  args.reduce([]) { |a, e| a + systemctl_commands(e) }
+  args.reduce([]) { |acc, elem| acc + systemctl_commands(elem) }
 end
 
 def systemctl_commands(service)

--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -61,7 +61,7 @@ systemd_service 'streamwebs-staging' do
     environment 'PATH' => '/home/streamwebs-staging/venv/bin'
     working_directory '/home/streamwebs-staging/streamwebs/streamwebs_frontend'
     pid_file '/home/streamwebs-staging/tmp/pids/gunicorn.pid'
-    exec_start '/home/streamwebs-staging/venv/bin/gunicorn -b 0.0.0.0:8080 '\
+    exec_start '/home/streamwebs-staging/venv/bin/gunicorn -b 0.0.0.0:8081 '\
       '-D --pid /home/streamwebs-staging/tmp/pids/gunicorn.pid '\
       'streamwebs_frontend.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
@@ -80,7 +80,7 @@ systemd_service 'streamwebs-production' do
     environment 'PATH' => '/home/streamwebs-production/venv/bin'
     working_directory '/home/streamwebs-production/streamwebs/streamwebs_frontend'
     pid_file '/home/streamwebs-production/tmp/pids/gunicorn.pid'
-    exec_start '/home/streamwebs-production/venv/bin/gunicorn -b 0.0.0.0:8081 '\
+    exec_start '/home/streamwebs-production/venv/bin/gunicorn -b 0.0.0.0:8080 '\
       '-D --pid /home/streamwebs-production/tmp/pids/gunicorn.pid '\
       'streamwebs_frontend.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'

--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -49,7 +49,7 @@ end
 
 #### Systemd Services ####
 
-systemd_service 'streamwebs-staging' do
+systemd_service 'streamwebs-staging-gunicorn' do
   description 'streamwebs staging app'
   after %w(network.target)
   install do
@@ -68,7 +68,7 @@ systemd_service 'streamwebs-staging' do
   end
 end
 
-systemd_service 'streamwebs-production' do
+systemd_service 'streamwebs-production-gunicorn' do
   description 'streamwebs production app'
   after %w(network.target)
   install do

--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -49,7 +49,7 @@ end
 
 #### Systemd Services ####
 
-systemd_service 'streamwebs-staging-gunicorn' do
+systemd_service 'streamwebs-staging' do
   description 'streamwebs staging app'
   after %w(network.target)
   install do
@@ -59,16 +59,16 @@ systemd_service 'streamwebs-staging-gunicorn' do
     type 'forking'
     user 'streamwebs-staging'
     environment 'PATH' => '/home/streamwebs-staging/venv/bin'
-    working_directory '/home/streamwebs-staging/streamwebs'
+    working_directory '/home/streamwebs-staging/streamwebs/streamwebs_frontend'
     pid_file '/home/streamwebs-staging/tmp/pids/gunicorn.pid'
     exec_start '/home/streamwebs-staging/venv/bin/gunicorn -b 0.0.0.0:8080 '\
       '-D --pid /home/streamwebs-staging/tmp/pids/gunicorn.pid '\
-      'streamwebs.wsgi:application'
+      'streamwebs_frontend.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
 end
 
-systemd_service 'streamwebs-production-gunicorn' do
+systemd_service 'streamwebs-production' do
   description 'streamwebs production app'
   after %w(network.target)
   install do
@@ -78,11 +78,11 @@ systemd_service 'streamwebs-production-gunicorn' do
     type 'forking'
     user 'streamwebs-production'
     environment 'PATH' => '/home/streamwebs-production/venv/bin'
-    working_directory '/home/streamwebs-production/streamwebs'
+    working_directory '/home/streamwebs-production/streamwebs/streamwebs_frontend'
     pid_file '/home/streamwebs-production/tmp/pids/gunicorn.pid'
     exec_start '/home/streamwebs-production/venv/bin/gunicorn -b 0.0.0.0:8081 '\
       '-D --pid /home/streamwebs-production/tmp/pids/gunicorn.pid '\
-      'streamwebs.wsgi:application'
+      'streamwebs_frontend.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
 end

--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -78,7 +78,8 @@ systemd_service 'streamwebs-production-gunicorn' do
     type 'forking'
     user 'streamwebs-production'
     environment 'PATH' => '/home/streamwebs-production/venv/bin'
-    working_directory '/home/streamwebs-production/streamwebs/streamwebs_frontend'
+    working_directory '/home/streamwebs-production/streamwebs/'\
+      'streamwebs_frontend'
     pid_file '/home/streamwebs-production/tmp/pids/gunicorn.pid'
     exec_start '/home/streamwebs-production/venv/bin/gunicorn -b 0.0.0.0:8080 '\
       '-D --pid /home/streamwebs-production/tmp/pids/gunicorn.pid '\

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -8,26 +8,26 @@ describe 'osl-app::app3' do
 
   it 'should create systemctl privs for streamwebs-staging' do
     expect(chef_run).to install_sudo('streamwebs-staging').with(
-      commands: ['/usr/bin/systemctl enable streamwebs-staging-gunicorn',
-                 '/usr/bin/systemctl disable streamwebs-staging-gunicorn',
-                 '/usr/bin/systemctl stop streamwebs-staging-gunicorn',
-                 '/usr/bin/systemctl start streamwebs-staging-gunicorn',
-                 '/usr/bin/systemctl status streamwebs-staging-gunicorn',
-                 '/usr/bin/systemctl reload streamwebs-staging-gunicorn',
-                 '/usr/bin/systemctl restart streamwebs-staging-gunicorn'],
+      commands: ['/usr/bin/systemctl enable streamwebs-staging',
+                 '/usr/bin/systemctl disable streamwebs-staging',
+                 '/usr/bin/systemctl stop streamwebs-staging',
+                 '/usr/bin/systemctl start streamwebs-staging',
+                 '/usr/bin/systemctl status streamwebs-staging',
+                 '/usr/bin/systemctl reload streamwebs-staging',
+                 '/usr/bin/systemctl restart streamwebs-staging'],
       nopasswd: true
     )
   end
 
   it 'should create systemctl privs for streamwebs-production' do
     expect(chef_run).to install_sudo('streamwebs-production').with(
-      commands: ['/usr/bin/systemctl enable streamwebs-production-gunicorn',
-                 '/usr/bin/systemctl disable streamwebs-production-gunicorn',
-                 '/usr/bin/systemctl stop streamwebs-production-gunicorn',
-                 '/usr/bin/systemctl start streamwebs-production-gunicorn',
-                 '/usr/bin/systemctl status streamwebs-production-gunicorn',
-                 '/usr/bin/systemctl reload streamwebs-production-gunicorn',
-                 '/usr/bin/systemctl restart streamwebs-production-gunicorn'],
+      commands: ['/usr/bin/systemctl enable streamwebs-production',
+                 '/usr/bin/systemctl disable streamwebs-production',
+                 '/usr/bin/systemctl stop streamwebs-production',
+                 '/usr/bin/systemctl start streamwebs-production',
+                 '/usr/bin/systemctl status streamwebs-production',
+                 '/usr/bin/systemctl reload streamwebs-production',
+                 '/usr/bin/systemctl restart streamwebs-production'],
       nopasswd: true
     )
   end

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -6,28 +6,28 @@ describe 'osl-app::app3' do
   end
   include_context 'common_stubs'
 
-  it 'should create systemctl privs for streamwebs-staging' do
+  it 'should create systemctl privs for streamwebs-staging-gunicorn' do
     expect(chef_run).to install_sudo('streamwebs-staging').with(
-      commands: ['/usr/bin/systemctl enable streamwebs-staging',
-                 '/usr/bin/systemctl disable streamwebs-staging',
-                 '/usr/bin/systemctl stop streamwebs-staging',
-                 '/usr/bin/systemctl start streamwebs-staging',
-                 '/usr/bin/systemctl status streamwebs-staging',
-                 '/usr/bin/systemctl reload streamwebs-staging',
-                 '/usr/bin/systemctl restart streamwebs-staging'],
+      commands: ['/usr/bin/systemctl enable streamwebs-staging-gunicorn',
+                 '/usr/bin/systemctl disable streamwebs-staging-gunicorn',
+                 '/usr/bin/systemctl stop streamwebs-staging-gunicorn',
+                 '/usr/bin/systemctl start streamwebs-staging-gunicorn',
+                 '/usr/bin/systemctl status streamwebs-staging-gunicorn',
+                 '/usr/bin/systemctl reload streamwebs-staging-gunicorn',
+                 '/usr/bin/systemctl restart streamwebs-staging-gunicorn'],
       nopasswd: true
     )
   end
 
-  it 'should create systemctl privs for streamwebs-production' do
+  it 'should create systemctl privs for streamwebs-production-gunicorn' do
     expect(chef_run).to install_sudo('streamwebs-production').with(
-      commands: ['/usr/bin/systemctl enable streamwebs-production',
-                 '/usr/bin/systemctl disable streamwebs-production',
-                 '/usr/bin/systemctl stop streamwebs-production',
-                 '/usr/bin/systemctl start streamwebs-production',
-                 '/usr/bin/systemctl status streamwebs-production',
-                 '/usr/bin/systemctl reload streamwebs-production',
-                 '/usr/bin/systemctl restart streamwebs-production'],
+      commands: ['/usr/bin/systemctl enable streamwebs-production-gunicorn',
+                 '/usr/bin/systemctl disable streamwebs-production-gunicorn',
+                 '/usr/bin/systemctl stop streamwebs-production-gunicorn',
+                 '/usr/bin/systemctl start streamwebs-production-gunicorn',
+                 '/usr/bin/systemctl status streamwebs-production-gunicorn',
+                 '/usr/bin/systemctl reload streamwebs-production-gunicorn',
+                 '/usr/bin/systemctl restart streamwebs-production-gunicorn'],
       nopasswd: true
     )
   end


### PR DESCRIPTION
This changes the systemd job name to conform to standard for names we use for other apps.

More importantly, reverse the port numbers for staging and production instances to match the numbers set up in haproxy.