### PR TITLE
Enable seperate logs for formsender's gunicorn.

### DIFF
--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -82,6 +82,9 @@ systemd_service 'formsender-staging-gunicorn' do
     pid_file '/home/formsender-staging/tmp/pids/gunicorn.pid'
     exec_start '/home/formsender-staging/venv/bin/gunicorn -b 0.0.0.0:8086 '\
       '-D --pid /home/formsender-staging/tmp/pids/gunicorn.pid '\
+      '--access-logfile /var/log/formsender-staging_access.log' \
+      '--error-logfile /var/log/formsender-staging_error.log' \
+      '--log-level debug' \
       'formsender.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
@@ -101,6 +104,9 @@ systemd_service 'formsender-production-gunicorn' do
     pid_file '/home/formsender-production/tmp/pids/gunicorn.pid'
     exec_start '/home/formsender-production/venv/bin/gunicorn -b 0.0.0.0:8085 '\
       '-D --pid /home/formsender-production/tmp/pids/gunicorn.pid '\
+      '--access-logfile /var/log/formsender-production_error.log' \
+      '--error-logfile /var/log/formsender-production_error.log' \
+      '--log-level debug' \
       'formsender.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end


### PR DESCRIPTION
Also enable error log and make logging level debug so that we can watch over things for next week or so.

