### PR TITLE
fix for failing formsender systemd service

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,5 +5,17 @@ AllCops:
   Exclude:
     - 'metadata.rb'
 
+Metrics/BlockNesting:
+  Max: 4
+Style/ClassAndModuleChildren:
+  Enabled: false
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
+Metrics/LineLength:
+  Max: 120
+Style/IfUnlessModifier:
+  MaxLineLength: 120
+Style/WhileUntilModifier:
+  MaxLineLength: 120
+Metrics/BlockLength:
+  Enabled: false

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -68,25 +68,8 @@ end
 
 #### Systemd Services ####
 
-# directories required for formsender gunicorn services to start successfully
-
-%w(
-  formsender-production
-  formsender-staging
-).each do |u|
-  %w(
-    logs
-    tmp
-    tmp/pids
-  ).each do |d|
-    directory "/home/#{u}/#{d}" do
-      owner u
-      group u
-      mode '0755'
-    end
-  end
-end
-
+# this service depends on the logs/ directory being present inside
+# ~formsender-staging/
 systemd_service 'formsender-staging-gunicorn' do
   description 'formsender staging app'
   after %w(network.target)
@@ -109,6 +92,8 @@ systemd_service 'formsender-staging-gunicorn' do
   end
 end
 
+# this service depends on the logs/ directory being present inside
+# ~formsender-production/
 systemd_service 'formsender-production-gunicorn' do
   description 'formsender production app'
   after %w(network.target)

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -82,8 +82,8 @@ systemd_service 'formsender-staging-gunicorn' do
     pid_file '/home/formsender-staging/tmp/pids/gunicorn.pid'
     exec_start '/home/formsender-staging/venv/bin/gunicorn -b 0.0.0.0:8086 '\
       '-D --pid /home/formsender-staging/tmp/pids/gunicorn.pid '\
-      '--access-logfile /var/log/formsender-staging_access.log '\
-      '--error-logfile /var/log/formsender-staging_error.log '\
+      '--access-logfile /home/formsender-staging/logs/formsender-staging_access.log '\
+      '--error-logfile /home/formsender-staging/logs/formsender-staging_error.log '\
       '--log-level debug '\
       'formsender.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
@@ -104,8 +104,8 @@ systemd_service 'formsender-production-gunicorn' do
     pid_file '/home/formsender-production/tmp/pids/gunicorn.pid'
     exec_start '/home/formsender-production/venv/bin/gunicorn -b 0.0.0.0:8085 '\
       '-D --pid /home/formsender-production/tmp/pids/gunicorn.pid '\
-      '--access-logfile /var/log/formsender-production_error.log '\
-      '--error-logfile /var/log/formsender-production_error.log '\
+      '--access-logfile /home/formsender-production/logs/formsender-production_access.log '\
+      '--error-logfile /home/formsender-production/logs/formsender-production_error.log '\
       '--log-level debug '\
       'formsender.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -68,6 +68,25 @@ end
 
 #### Systemd Services ####
 
+# directories required for formsender gunicorn services to start successfully
+
+%w(
+  formsender-production
+  formsender-staging
+).each do |u|
+  %w(
+    logs
+    tmp
+    tmp/pids
+  ).each do |d|
+    directory "/home/#{u}/#{d}" do
+      owner u
+      group u
+      mode '0755'
+    end
+  end
+end
+
 systemd_service 'formsender-staging-gunicorn' do
   description 'formsender staging app'
   after %w(network.target)
@@ -82,8 +101,8 @@ systemd_service 'formsender-staging-gunicorn' do
     pid_file '/home/formsender-staging/tmp/pids/gunicorn.pid'
     exec_start '/home/formsender-staging/venv/bin/gunicorn -b 0.0.0.0:8086 '\
       '-D --pid /home/formsender-staging/tmp/pids/gunicorn.pid '\
-      '--access-logfile /home/formsender-staging/logs/formsender-staging_access.log '\
-      '--error-logfile /home/formsender-staging/logs/formsender-staging_error.log '\
+      '--access-logfile /home/formsender-staging/logs/access.log '\
+      '--error-logfile /home/formsender-staging/logs/error.log '\
       '--log-level debug '\
       'formsender.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
@@ -104,8 +123,8 @@ systemd_service 'formsender-production-gunicorn' do
     pid_file '/home/formsender-production/tmp/pids/gunicorn.pid'
     exec_start '/home/formsender-production/venv/bin/gunicorn -b 0.0.0.0:8085 '\
       '-D --pid /home/formsender-production/tmp/pids/gunicorn.pid '\
-      '--access-logfile /home/formsender-production/logs/formsender-production_access.log '\
-      '--error-logfile /home/formsender-production/logs/formsender-production_error.log '\
+      '--access-logfile /home/formsender-production/logs/access.log '\
+      '--error-logfile /home/formsender-production/logs/error.log '\
       '--log-level debug '\
       'formsender.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'

--- a/spec/app2_spec.rb
+++ b/spec/app2_spec.rb
@@ -97,25 +97,6 @@ describe 'osl-app::app2' do
     )
   end
 
-  %w(
-    formsender-production
-    formsender-staging
-  ).each do |u|
-    %w(
-      logs
-      tmp
-      tmp/pids
-    ).each do |d|
-      it do
-        expect(chef_run).to create_directory("/home/#{u}/#{d}").with(
-          user: u,
-          group: u,
-          mode: '0755'
-        )
-      end
-    end
-  end
-
   %w(formsender-staging-gunicorn formsender-production-gunicorn
      iam-staging iam-production
      timesync-staging timesync-production

--- a/spec/app2_spec.rb
+++ b/spec/app2_spec.rb
@@ -97,6 +97,25 @@ describe 'osl-app::app2' do
     )
   end
 
+  %w(
+    formsender-production
+    formsender-staging
+  ).each do |u|
+    %w(
+      logs
+      tmp
+      tmp/pids
+    ).each do |d|
+      it do
+        expect(chef_run).to create_directory("/home/#{u}/#{d}").with(
+          user: u,
+          group: u,
+          mode: '0755'
+        )
+      end
+    end
+  end
+
   %w(formsender-staging-gunicorn formsender-production-gunicorn
      iam-staging iam-production
      timesync-staging timesync-production


### PR DESCRIPTION
Moves the formsender logs to the home directories where apps are deployed.
This also includes creations of directories because they are required by the systemd service to start successfully.

Have tested it after manually cloning and setting up the app on my kitchen vm for production and staging.

Thanks @ramereth 

No integration tests for now because the service cannot start without the app being deployed which is out of scope of this cookbook. Will open an issue for integration tests for directories and existence of service.

I have a question. Why does the recipe not handle _starting_ of the service too?