### PR TITLE
Set proper permissions for logrotate

### DIFF
--- a/recipes/app1.rb
+++ b/recipes/app1.rb
@@ -145,6 +145,7 @@ end
     path "/home/openid-#{type}/shared/log/*"
     postrotate "/bin/kill -USR1 /home/openid-#{type}/current/tmp/pids/unicorn.pid"
     frequency 'daily'
+    su "openid-#{type} openid-#{type}"
     rotate 30
   end
 end

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -67,6 +67,7 @@ describe 'osl-app::app1' do
         path: "/home/openid-#{type}/shared/log/*",
         frequency: 'daily',
         postrotate: "/bin/kill -USR1 /home/openid-#{type}/current/tmp/pids/unicorn.pid",
+        su: "openid-#{type} openid-#{type}",
         rotate: 30
       )
     end


### PR DESCRIPTION
Logrotate wasn't running on app1, investigating the issue revealed that it wouldn't rotate logs that were not owned by `root`. This sets the user and group for logrotate that is consistent with app1 permissions, so logrotate should work now.