### PR TITLE
Use command to run replicant redmine until we upgrade

### DIFF
--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -192,6 +192,6 @@ systemd_service 'replicant-redmine-unicorn' do
     user 'replicant'
     working_directory '/home/replicant/redmine'
     pid_file '/home/replicant/pids/unicorn.pid'
-    exec_start 'RAILS_ENV=production ./script/server -b 140.211.9.86 -p 8090'
+    exec_start '/home/replicant/.rvm/bin/rvm 1.8.7-p374 exec ./script/server -b 140.211.9.86 -p 8090'
   end
 end

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -192,7 +192,6 @@ systemd_service 'replicant-redmine-unicorn' do
     user 'replicant'
     working_directory '/home/replicant/redmine'
     pid_file '/home/replicant/pids/unicorn.pid'
-    exec_start '/home/replicant/.rvm/bin/rvm 2.3.0 do bundle exec '\
-      'unicorn -l 8090 -c unicorn.rb -E deployment -D'
+    exec_start 'RAILS_ENV=production ./script/server -b 140.211.9.86 -p 8090'
   end
 end


### PR DESCRIPTION
Unicorn requires a newer version of ruby, so chaning to this in the interim until we upgrade the redmine. 