### PR TITLE
Fahlmant/quick fix

### DIFF
--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -190,9 +190,10 @@ systemd_service 'replicant-redmine-unicorn' do
   service do
     type 'forking'
     user 'replicant'
+    environment 'RAILS_ENV' => 'production'
     working_directory '/home/replicant/redmine'
     pid_file '/home/replicant/pids/unicorn.pid'
-    exec_start 'RAILS_ENV=production /home/replicant/.rvm/bin/rvm 1.8.7-p374 '\
+    exec_start '/home/replicant/.rvm/bin/rvm 1.8.7-p374 '\
       'exec ./script/server -b 140.211.9.86 -p 8090'
   end
 end


### PR DESCRIPTION
Potential fix for the replicant redmine systemd problem. `forking` means that systemd expects the application to call `fork()`, but I don't believe rails is doing that. 