### PR TITLE
Change type from forking to simple

### DIFF
--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -188,7 +188,7 @@ systemd_service 'replicant-redmine-unicorn' do
     wanted_by 'multi-user.target'
   end
   service do
-    type 'forking'
+    type 'simple'
     user 'replicant'
     environment 'RAILS_ENV' => 'production'
     working_directory '/home/replicant/redmine'


### PR DESCRIPTION
Potential fix for the replicant redmine systemd problem. forking means that systemd expects the application to call fork(), but I don't believe rails is doing that.

(Pushed to wrong branch and opened PR on it)