### PR TITLE
only rotate new log files

### DIFF
--- a/recipes/app1.rb
+++ b/recipes/app1.rb
@@ -142,7 +142,7 @@ end
 # by sending it a USR1 signal, which will cause it reopen its logs
 %w(production staging).each do |type|
   logrotate_app "OpenID-#{type}" do
-    path "/home/openid-#{type}/shared/log/*"
+    path "/home/openid-#{type}/shared/log/*.log"
     postrotate "/bin/kill -USR1 /home/openid-#{type}/current/tmp/pids/unicorn.pid"
     frequency 'daily'
     su "openid-#{type} openid-#{type}"

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -64,7 +64,7 @@ describe 'osl-app::app1' do
   %w(production staging).each do |type|
     it "should create LogRotate service for OpenID-#{type}" do
       expect(chef_run).to enable_logrotate_app("OpenID-#{type}").with(
-        path: "/home/openid-#{type}/shared/log/*",
+        path: "/home/openid-#{type}/shared/log/*.log",
         frequency: 'daily',
         postrotate: "/bin/kill -USR1 /home/openid-#{type}/current/tmp/pids/unicorn.pid",
         su: "openid-#{type} openid-#{type}",


### PR DESCRIPTION
Customer has pointed out in RT#29447 that logrotate is a special kind of broken. This simple patch ensures that only the base `.log` file is rotated, and rotated log files are not treated as separate rotations.