### PR TITLE
update replicant redmine command to redmine 3.3.3

### DIFF
--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -193,6 +193,6 @@ systemd_service 'replicant-redmine-unicorn' do
     environment 'RAILS_ENV' => 'production'
     working_directory '/home/replicant/redmine'
     pid_file '/home/replicant/pids/unicorn.pid'
-    exec_start '/home/replicant/.rvm/bin/rvm 1.8.7-p374 exec ./script/server -b 140.211.9.86 -p 8090'
+    exec_start '/home/replicant/.rvm/bin/rvm 2.3.0 exec  ./bin/rails server -e production -b 140.211.9.86 -p 8090'
   end
 end


### PR DESCRIPTION
This change makes sure systemd is running the proper command for Replicant's redmine instance after its updated to 3.3.3. This will only be merged after the upgrade taking place on 6/8. 