### PR TITLE
rename the redmine app systemd service aptly

### DIFF
--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -62,7 +62,7 @@ end
 
 sudo 'replicant' do
   user 'replicant'
-  commands sudo_commands('replicant-redmine-unicorn')
+  commands sudo_commands('replicant-redmine-webrick')
   nopasswd true
 end
 
@@ -181,7 +181,7 @@ systemd_service 'timesync-production' do
   end
 end
 
-systemd_service 'replicant-redmine-unicorn' do
+systemd_service 'replicant-redmine-webrick' do
   description 'Replicant Redmine'
   after %(network.target)
   install do

--- a/spec/app2_spec.rb
+++ b/spec/app2_spec.rb
@@ -86,13 +86,13 @@ describe 'osl-app::app2' do
 
   it 'should create systemctl privs for replicant' do
     expect(chef_run).to install_sudo('replicant').with(
-      commands: ['/usr/bin/systemctl enable replicant-redmine-unicorn',
-                 '/usr/bin/systemctl disable replicant-redmine-unicorn',
-                 '/usr/bin/systemctl stop replicant-redmine-unicorn',
-                 '/usr/bin/systemctl start replicant-redmine-unicorn',
-                 '/usr/bin/systemctl status replicant-redmine-unicorn',
-                 '/usr/bin/systemctl reload replicant-redmine-unicorn',
-                 '/usr/bin/systemctl restart replicant-redmine-unicorn'],
+      commands: ['/usr/bin/systemctl enable replicant-redmine-webrick',
+                 '/usr/bin/systemctl disable replicant-redmine-webrick',
+                 '/usr/bin/systemctl stop replicant-redmine-webrick',
+                 '/usr/bin/systemctl start replicant-redmine-webrick',
+                 '/usr/bin/systemctl status replicant-redmine-webrick',
+                 '/usr/bin/systemctl reload replicant-redmine-webrick',
+                 '/usr/bin/systemctl restart replicant-redmine-webrick'],
       nopasswd: true
     )
   end
@@ -100,7 +100,7 @@ describe 'osl-app::app2' do
   %w(formsender-staging-gunicorn formsender-production-gunicorn
      iam-staging iam-production
      timesync-staging timesync-production
-     replicant-redmine-unicorn).each do |s|
+     replicant-redmine-webrick).each do |s|
     it "should create system service #{s}" do
       expect(chef_run).to create_systemd_service(s)
     end


### PR DESCRIPTION
I will kill and rm the old service manually ~once the new one starts~ just after the PR is approved and before a chef-client run, if that's okay with the on call.