### PR TITLE
Use unicorn instead of webrick in replicant's systemd command

### DIFF
--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -192,7 +192,7 @@ systemd_service 'replicant-redmine-unicorn' do
     user 'replicant'
     environment 'RAILS_ENV' => 'production'
     working_directory '/home/replicant/redmine'
-    pid_file '/home/replicant/pids/unicorn.pid'
-    exec_start '/home/replicant/.rvm/bin/rvm 2.3.0 exec  ./bin/rails server -e production -b 140.211.9.86 -p 8090'
+    pid_file '/home/replicant/redmine/pids/unicorn.pid'
+    exec_start '/home/replicant/.rvm/bin/rvm 2.3.0 do bundle exec unicorn -l 8090 -c unicorn.rb -E production -D'
   end
 end


### PR DESCRIPTION
Since we upgraded redmine we can now use unicorn as the backend server. This will resolve [29558](https://support.osuosl.org/Ticket/Display.html?id=29558)