### PR TITLE
Enable systemd services and improve tests.

### DIFF
--- a/recipes/app1.rb
+++ b/recipes/app1.rb
@@ -62,6 +62,7 @@ systemd_service 'openid-staging-unicorn' do
     'deployment -D'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'openid-staging-delayed-job' do
@@ -81,6 +82,7 @@ systemd_service 'openid-staging-delayed-job' do
     exec_reload '/home/openid-staging/.rvm/bin/rvm 2.2.4 do bundle exec '\
     'bin/delayed_job -n 2 restart'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'openid-production-unicorn' do
@@ -102,6 +104,7 @@ systemd_service 'openid-production-unicorn' do
     '-E deployment -D'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'openid-production-delayed-job' do
@@ -121,6 +124,7 @@ systemd_service 'openid-production-delayed-job' do
     exec_reload '/home/openid-production/.rvm/bin/rvm 2.2.4 do bundle exec '\
     'bin/delayed_job -n 2 restart'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'fenestra' do
@@ -137,6 +141,7 @@ systemd_service 'fenestra' do
     exec_start '/home/fenestra/.rvm/bin/rvm 2.2.5 do bundle exec unicorn -l '\
     '8082 -c config/unicorn.rb -E deployment -D'
   end
+  action [:create, :enable]
 end
 
 # Setup logrotate, also make sure that unicorn releases the file handles

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -90,6 +90,7 @@ systemd_service 'formsender-staging-gunicorn' do
       'formsender.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
+  action [:create, :enable]
 end
 
 # this service depends on the logs/ directory being present inside
@@ -114,6 +115,7 @@ systemd_service 'formsender-production-gunicorn' do
       'formsender.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'iam-staging' do
@@ -130,6 +132,7 @@ systemd_service 'iam-staging' do
     exec_start '/home/iam-staging/.rvm/bin/rvm 2.3.0 do bundle exec '\
       'unicorn -l 8084 -c unicorn.rb -E deployment -D'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'iam-production' do
@@ -146,6 +149,7 @@ systemd_service 'iam-production' do
     exec_start '/home/iam-production/.rvm/bin/rvm 2.3.0 do bundle exec '\
       'unicorn -l 8083 -c unicorn.rb -E deployment -D'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'timesync-staging' do
@@ -162,6 +166,7 @@ systemd_service 'timesync-staging' do
     # Port 8089 (set in env file)
     exec_start '/usr/local/bin/node /home/timesync-staging/timesync/src/app.js'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'timesync-production' do
@@ -179,6 +184,7 @@ systemd_service 'timesync-production' do
     exec_start '/usr/local/bin/node ' \
       '/home/timesync-production/timesync/src/app.js'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'replicant-redmine-unicorn' do
@@ -195,4 +201,5 @@ systemd_service 'replicant-redmine-unicorn' do
     pid_file '/home/replicant/redmine/pids/unicorn.pid'
     exec_start '/home/replicant/.rvm/bin/rvm 2.3.0 do bundle exec unicorn -l 8090 -c unicorn.rb -E production -D'
   end
+  action [:create, :enable]
 end

--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -69,6 +69,7 @@ systemd_service 'streamwebs-staging-gunicorn' do
       'streamwebs_frontend.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'streamwebs-production-gunicorn' do
@@ -91,6 +92,7 @@ systemd_service 'streamwebs-production-gunicorn' do
       'streamwebs_frontend.wsgi:application'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'timesync-web-staging' do
@@ -109,6 +111,7 @@ systemd_service 'timesync-web-staging' do
       '-D --pid /home/timesync-web-staging/tmp/pids/gunicorn.pid wsgi:app'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
+  action [:create, :enable]
 end
 
 systemd_service 'timesync-web-production' do
@@ -128,6 +131,7 @@ systemd_service 'timesync-web-production' do
       '-D --pid /home/timesync-web-production/tmp/pids/gunicorn.pid wsgi:app'
     exec_reload '/bin/kill -USR2 $MAINPID'
   end
+  action [:create, :enable]
 end
 
 # Nginx

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -55,10 +55,29 @@ describe 'osl-app::app1' do
     )
   end
 
-  %w(openid-staging-unicorn openid-staging-delayed-job
-     openid-production-unicorn openid-production-delayed-job).each do |s|
+  it 'should create systemctl privs for fenestra' do
+    expect(chef_run).to install_sudo('fenestra').with(
+      commands: ['/usr/bin/systemctl enable fenestra',
+                 '/usr/bin/systemctl disable fenestra',
+                 '/usr/bin/systemctl stop fenestra',
+                 '/usr/bin/systemctl start fenestra',
+                 '/usr/bin/systemctl status fenestra',
+                 '/usr/bin/systemctl reload fenestra',
+                 '/usr/bin/systemctl restart fenestra'],
+      nopasswd: true
+    )
+  end
+
+  %w(openid-staging-unicorn
+     openid-staging-delayed-job
+     openid-production-unicorn
+     openid-production-delayed-job
+     fenestra).each do |s|
     it "should create system service #{s}" do
       expect(chef_run).to create_systemd_service(s)
+    end
+    it "should enable system service #{s}" do
+      expect(chef_run).to enable_systemd_service(s)
     end
   end
 

--- a/spec/app2_spec.rb
+++ b/spec/app2_spec.rb
@@ -96,13 +96,18 @@ describe 'osl-app::app2' do
       nopasswd: true
     )
   end
-
-  %w(formsender-staging-gunicorn formsender-production-gunicorn
-     iam-staging iam-production
-     timesync-staging timesync-production
-     replicant-redmine-unicorn).each do |s|
+  %w(formsender-production-gunicorn
+     formsender-staging-gunicorn
+     iam-production
+     iam-staging
+     replicant-redmine-unicorn
+     timesync-production
+     timesync-staging).each do |s|
     it "should create system service #{s}" do
       expect(chef_run).to create_systemd_service(s)
+    end
+    it "should enable system service #{s}" do
+      expect(chef_run).to enable_systemd_service(s)
     end
   end
 end

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -58,10 +58,15 @@ describe 'osl-app::app3' do
     )
   end
 
-  %w(streamwebs-staging-gunicorn streamwebs-production-gunicorn
-     timesync-web-staging timesync-web-production).each do |s|
+  %w(streamwebs-production-gunicorn
+     streamwebs-staging-gunicorn
+     timesync-web-production
+     timesync-web-staging).each do |s|
     it "should create system service #{s}" do
       expect(chef_run).to create_systemd_service(s)
+    end
+    it "should enable system service #{s}" do
+      expect(chef_run).to enable_systemd_service(s)
     end
   end
   it do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -4,8 +4,49 @@ describe 'osl-app::default' do
   cached(:chef_run) do
     ChefSpec::SoloRunner.new(CENTOS_7).converge('sudo', described_recipe)
   end
+
   include_context 'common_stubs'
+
   it do
     expect { chef_run }.to_not raise_error
+  end
+
+  it do
+    expect(chef_run).to include_recipe 'yum-epel::default'
+  end
+
+  it do
+    %w(
+      automake
+      freetype-devel
+      gdal-python
+      geos-python
+      ImageMagick-devel
+      libffi-devel
+      libjpeg-turbo-devel
+      libpng-devel
+      libtool
+      libyaml-devel
+      mariadb-devel
+      openssl-devel
+      postgis
+      postgresql-devel
+      proj
+      proj-nad
+      python-psycopg2
+      readline-devel
+      sqlite-devel
+      zlib-devel
+    ).each do |p|
+      expect(chef_run).to install_package(p)
+    end
+  end
+
+  it do
+    expect(chef_run).to install_python_runtime 2
+  end
+
+  it do
+    expect(chef_run).to create_directory('/etc/systemd/system').with(mode: 0750)
   end
 end

--- a/test/integration/app1/serverspec/app1_spec.rb
+++ b/test/integration/app1/serverspec/app1_spec.rb
@@ -1,0 +1,13 @@
+require 'serverspec'
+
+set :backend, :exec
+
+%w(fenestra
+   openid-production-delayed-job
+   openid-production-unicorn
+   openid-staging-delayed-job
+   openid-staging-unicorn).each do |s|
+     describe service(s) do
+       it { should be_enabled }
+     end
+   end

--- a/test/integration/app2/serverspec/app2_spec.rb
+++ b/test/integration/app2/serverspec/app2_spec.rb
@@ -1,0 +1,15 @@
+require 'serverspec'
+
+set :backend, :exec
+
+%w(formsender-production-gunicorn
+   formsender-staging-gunicorn
+   iam-production
+   iam-staging
+   replicant-redmine-unicorn
+   timesync-production
+   timesync-staging).each do |s|
+     describe service(s) do
+       it { should be_enabled }
+     end
+   end

--- a/test/integration/app3/serverspec/app3_spec.rb
+++ b/test/integration/app3/serverspec/app3_spec.rb
@@ -2,7 +2,7 @@ require 'serverspec'
 
 set :backend, :exec
 
-describe command('curl -q -H "Host: new.streamwebs.org" http://127.0.0.1/streamwebs-production/media/index.html') do
+describe command('curl -q -H "Host: streamwebs.org" http://127.0.0.1/streamwebs-production/media/index.html') do
   its(:stdout) { should match(/^streamwebs-production$/) }
 end
 
@@ -10,3 +10,12 @@ describe command('curl -q -H "Host: streamwebs-staging.osuosl.org" \
 http://127.0.0.1/streamwebs-staging/media/index.html') do
   its(:stdout) { should match(/^streamwebs-staging$/) }
 end
+
+%w(streamwebs-production-gunicorn
+   streamwebs-staging-gunicorn
+   timesync-web-production
+   timesync-web-staging).each do |s|
+     describe service(s) do
+       it { should be_enabled }
+     end
+   end


### PR DESCRIPTION
For [RT#29956](https://support.osuosl.org/Ticket/Display.html?id=29956). We've had a problem where streamwebs wouldn't come back online after a reboot, which seems to be because the systemd services in `osl-app` are not enabled by default. This was made worse by the lack of monitoring in Nagios.

-----

* I've gone through the systemd services and enabled all ~~of those that are currently running in production (assuming that is an accurate reflection of what should/shouldn't be running).~~
* I've added HTTP and HTTPS monitoring for `streamwebs.org` and `streamwebs-staging.osuosl.org` (in merge request on GitLab).
* I've improved the test coverage.