### PR TITLE
Use simple systemd type for timesync application

### DIFF
--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -77,6 +77,7 @@ osl_app 'timesync-staging' do
   environment_file '/home/timesync-staging/timesync.env'
   working_directory '/home/timesync-staging/timesync'
   pid_file '/home/timesync-staging/pids/timesync.pid'
+  service_type 'simple'
 end
 
 osl_app 'timesync-production' do
@@ -86,6 +87,7 @@ osl_app 'timesync-production' do
   environment_file '/home/timesync-production/timesync.env'
   working_directory '/home/timesync-production/timesync'
   pid_file '/home/timesync-production/pids/timesync.pid'
+  service_type 'simple'
 end
 
 osl_app 'replicant-redmine-unicorn' do

--- a/spec/app2_spec.rb
+++ b/spec/app2_spec.rb
@@ -93,7 +93,8 @@ describe 'osl-app::app2' do
         start_cmd: "/usr/local/bin/node /home/timesync-#{env}/timesync/src/app.js",
         environment_file: "/home/timesync-#{env}/timesync.env",
         working_directory: "/home/timesync-#{env}/timesync",
-        pid_file: "/home/timesync-#{env}/pids/timesync.pid"
+        pid_file: "/home/timesync-#{env}/pids/timesync.pid",
+        service_type: 'simple'
       )
     end
 
@@ -102,7 +103,7 @@ describe 'osl-app::app2' do
         description: 'Time tracker',
         after: %w(network.target),
         wanted_by: 'multi-user.target',
-        type: 'forking',
+        type: 'simple',
         user: "timesync-#{env}",
         environment: {},
         environment_file: "/home/timesync-#{env}/timesync.env",


### PR DESCRIPTION
A recent update to systemd seems to have broken the timesync systemd unit file.
The binary is running but systemd never thinks it forks. According to this blog
[1], it seems we should be using the simple type anyway. I confirmed this works
manually on the production node.

[1] https://nodesource.com/blog/running-your-node-js-app-with-systemd-part-1/