### PR TITLE
Fix mismatch in streamwebs' service PID file

### DIFF
--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -34,7 +34,7 @@ osl_app 'streamwebs-staging-gunicorn' do
     'streamwebs_frontend.wsgi:application'
   environment 'PATH' => '/home/streamwebs-staging/venv/bin'
   working_directory '/home/streamwebs-staging/streamwebs/streamwebs_frontend'
-  pid_file '/home/streamwebs-staging/tmp/pids/unicorn.pid'
+  pid_file '/home/streamwebs-staging/tmp/pids/gunicorn.pid'
 end
 
 osl_app 'streamwebs-production-gunicorn' do
@@ -47,7 +47,7 @@ osl_app 'streamwebs-production-gunicorn' do
     'streamwebs_frontend.wsgi:application'
   environment 'PATH' => '/home/streamwebs-production/venv/bin'
   working_directory '/home/streamwebs-production/streamwebs/streamwebs_frontend'
-  pid_file '/home/streamwebs-production/tmp/pids/unicorn.pid'
+  pid_file '/home/streamwebs-production/tmp/pids/gunicorn.pid'
 end
 
 osl_app 'timesync-web-staging' do

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -20,7 +20,7 @@ describe 'osl-app::app3' do
           'streamwebs_frontend.wsgi:application',
         environment: { 'PATH' => "/home/streamwebs-#{env}/venv/bin" },
         working_directory: "/home/streamwebs-#{env}/streamwebs/streamwebs_frontend",
-        pid_file: "/home/streamwebs-#{env}/tmp/pids/unicorn.pid"
+        pid_file: "/home/streamwebs-#{env}/tmp/pids/gunicorn.pid"
       )
     end
 
@@ -35,7 +35,7 @@ describe 'osl-app::app3' do
         environment: { 'PATH' => "/home/streamwebs-#{env}/venv/bin" },
         environment_file: nil,
         working_directory: "/home/streamwebs-#{env}/streamwebs/streamwebs_frontend",
-        pid_file: "/home/streamwebs-#{env}/tmp/pids/unicorn.pid",
+        pid_file: "/home/streamwebs-#{env}/tmp/pids/gunicorn.pid",
         exec_start: "/home/streamwebs-#{env}/venv/bin/gunicorn -b 0.0.0.0:#{port} "\
           "-D --pid /home/streamwebs-#{env}/tmp/pids/gunicorn.pid "\
           "--access-logfile /home/streamwebs-#{env}/logs/access.log "\


### PR DESCRIPTION
There's a mismatch between the PID file used by the app and the one used by systemd.
This caused systemd to timeout on starting streamwebs even though it started successfully.