### PR TITLE
Fix typo in timesync-web systemd configs

### DIFF
--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -56,7 +56,7 @@ osl_app 'timesync-web-staging' do
     '-D --pid /home/timesync-web-staging/tmp/pids/gunicorn.pid wsgi:app'
   environment 'PATH' => '/home/timesync-web-staging/venv/bin'
   working_directory '/home/timesync-web-staging/timesync-web'
-  pid_file '/home/timesync-web-staging/tmp/pids/unicorn.pid'
+  pid_file '/home/timesync-web-staging/tmp/pids/gunicorn.pid'
 end
 
 osl_app 'timesync-web-production' do
@@ -66,7 +66,7 @@ osl_app 'timesync-web-production' do
     '-D --pid /home/timesync-web-production/tmp/pids/gunicorn.pid wsgi:app'
   environment 'PATH' => '/home/timesync-web-production/venv/bin'
   working_directory '/home/timesync-web-production/timesync-web'
-  pid_file '/home/timesync-web-production/tmp/pids/unicorn.pid'
+  pid_file '/home/timesync-web-production/tmp/pids/gunicorn.pid'
 end
 
 # Nginx

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -53,7 +53,7 @@ describe 'osl-app::app3' do
           "-D --pid /home/timesync-web-#{env}/tmp/pids/gunicorn.pid wsgi:app",
         environment: { 'PATH' => "/home/timesync-web-#{env}/venv/bin" },
         working_directory: "/home/timesync-web-#{env}/timesync-web",
-        pid_file: "/home/timesync-web-#{env}/tmp/pids/unicorn.pid"
+        pid_file: "/home/timesync-web-#{env}/tmp/pids/gunicorn.pid"
       )
     end
 
@@ -68,7 +68,7 @@ describe 'osl-app::app3' do
         environment: { 'PATH' => "/home/timesync-web-#{env}/venv/bin" },
         environment_file: nil,
         working_directory: "/home/timesync-web-#{env}/timesync-web",
-        pid_file: "/home/timesync-web-#{env}/tmp/pids/unicorn.pid",
+        pid_file: "/home/timesync-web-#{env}/tmp/pids/gunicorn.pid",
         exec_start: "/home/timesync-web-#{env}/venv/bin/gunicorn -b 0.0.0.0:#{port} "\
           "-D --pid /home/timesync-web-#{env}/tmp/pids/gunicorn.pid wsgi:app",
         exec_reload: '/bin/kill -USR2 $MAINPID'


### PR DESCRIPTION
Not sure how this worked before, but the recent systemd update seems to have
made this problem apparent.