### PR TITLE
Add mulgara SVN bind mount

### DIFF
--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -100,8 +100,10 @@ nginx_app 'app3.osuosl.org' do
 end
 
 # Docker containers
-directory '/data/docker/code.mulgara.org' do
-  recursive true
+%w(/data/docker/code.mulgara.org /data/docker/code.mulgara.org-svn).each do |dir|
+  directory dir do
+    recursive true
+  end
 end
 
 mulgara_redmine_creds = data_bag_item('mulgara_redmine', 'mysql_creds')
@@ -123,7 +125,10 @@ docker_container 'code.mulgara.org' do
   tag '4.0.4'
   port '8084:3000'
   restart_policy 'always'
-  volumes ['/data/docker/code.mulgara.org:/usr/src/redmine/files']
+  volumes [
+    '/data/docker/code.mulgara.org:/usr/src/redmine/files',
+    '/data/docker/code.mulgara.org-svn:/var/lib/svn/mulgara/mulgara',
+  ]
   env [
     "REDMINE_DB_MYSQL=#{mulgara_db_host}",
     "REDMINE_DB_DATABASE=#{mulgara_redmine_creds['db_db']}",

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -137,10 +137,12 @@ describe 'osl-app::app3' do
     )
   end
 
-  it do
-    expect(chef_run).to create_directory('/data/docker/code.mulgara.org').with(
-      recursive: true
-    )
+  %w(/data/docker/code.mulgara.org /data/docker/code.mulgara.org-svn).each do |dir|
+    it do
+      expect(chef_run).to create_directory(dir).with(
+        recursive: true
+      )
+    end
   end
 
   it do
@@ -158,7 +160,10 @@ describe 'osl-app::app3' do
       # This needs to be volumes_binds, since the volumes property gets coerced into a volumes_binds property if it's
       # passed an entry that specifies a bind mount
       # https://github.com/chef-cookbooks/docker/blob/v4.9.3/libraries/docker_container.rb#L210
-      volumes_binds: ['/data/docker/code.mulgara.org:/usr/src/redmine/files'],
+      volumes_binds: [
+        '/data/docker/code.mulgara.org:/usr/src/redmine/files',
+        '/data/docker/code.mulgara.org-svn:/var/lib/svn/mulgara/mulgara',
+      ],
       env: [
         'REDMINE_DB_MYSQL=testdb.osuosl.bak',
         'REDMINE_DB_DATABASE=fakedb',


### PR DESCRIPTION
When viewing the docker-based website of `code.mulgara.org` by pointing it to `vip-lb1`, this link is broken because the SVN repo isn't in the docker container: `http://code.mulgara.org/projects/mulgara/repository`.

After this PR is merged, I'll need to copy the SVN repo from `mulgara.osuosl.org:/var/lib/svn/mulgara/mulgara` to `app3.osuosl.org:/data/docker/code.mulgara.org-svn`