### PR TITLE
Add Etherpad Docker containers

### DIFF
--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -135,8 +135,6 @@ docker_container 'code.mulgara.org' do
   sensitive true
 end
 
-# Check if attribute is set for testing
-
 etherpad_tag = '1.8.6-2020.11.13.2015'
 etherpad_snowdrift_tag = '1.8.6-2020.11.13.2015'
 

--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -117,11 +117,7 @@ docker_image 'library/redmine' do
 end
 
 # Check if attribute is set for testing
-mulgara_db_host = if node['osl-app'].attribute?('db_hostname')
-                    node['osl-app']['db_hostname']
-                  else
-                    mulgara_redmine_creds['db_hostname']
-                  end
+mulgara_db_host = node['osl-app'].attribute?('db_hostname') ? node['osl-app']['db_hostname'] : mulgara_redmine_creds['db_hostname']
 
 docker_container 'code.mulgara.org' do
   repo 'redmine'
@@ -144,11 +140,7 @@ end
   ['etherpad-snowdrift.osuosl.org', 8086, 'osuosl/etherpad-snowdrift', data_bag_item('etherpad', 'mysql_creds_snowdrift')],
 ].each do |hostname, port, image, creds|
   # Check if attribute is set for testing
-  db_host = if node['osl-app'].attribute?('db_hostname')
-              node['osl-app']['db_hostname']
-            else
-              creds['db_hostname']
-            end
+  db_host = node['osl-app'].attribute?('db_hostname') ? node['osl-app']['db_hostname'] : creds['db_hostname']
 
   docker_image image do
     tag 'latest'

--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -136,13 +136,15 @@ docker_container 'code.mulgara.org' do
 end
 
 # Check if attribute is set for testing
-db_host = node['osl-app'].attribute?('db_hostname') ? node['osl-app']['db_hostname'] : creds['db_hostname']
 
 etherpad_tag = '1.8.6-2020.11.13.2015'
-etherpad_sd_tag = '1.8.6-2020.11.13.2015'
+etherpad_snowdrift_tag = '1.8.6-2020.11.13.2015'
 
 etherpad_creds = data_bag_item('etherpad', 'mysql_creds_osl')
-etherpad_sd_creds = data_bag_item('etherpad', 'mysql_creds_snowdrift')
+etherpad_snowdrift_creds = data_bag_item('etherpad', 'mysql_creds_snowdrift')
+
+etherpad_db_host = node['osl-app'].attribute?('db_hostname') ? node['osl-app']['db_hostname'] : etherpad_creds['db_hostname']
+etherpad_snowdrift_db_host = node['osl-app'].attribute?('db_hostname') ? node['osl-app']['db_hostname'] : etherpad_snowdrift_creds['db_hostname']
 
 docker_image 'osuosl/etherpad' do
   tag etherpad_tag
@@ -156,7 +158,7 @@ docker_container 'etherpad-lite.osuosl.org' do
   restart_policy 'always'
   env [
     'DB_TYPE=mysql',
-    "DB_HOST=#{db_host}",
+    "DB_HOST=#{etherpad_db_host}",
     "DB_NAME=#{etherpad_creds['db_db']}",
     "DB_USER=#{etherpad_creds['db_user']}",
     "DB_PASS=#{etherpad_creds['db_passwd']}",
@@ -165,21 +167,21 @@ docker_container 'etherpad-lite.osuosl.org' do
 end
 
 docker_image 'osuosl/etherpad-snowdrift' do
-  tag etherpad_sd_tag
+  tag etherpad_snowdrift_tag
   action :pull
 end
 
 docker_container 'etherpad-snowdrift.osuosl.org' do
   repo 'osuosl/etherpad-snowdrift'
-  tag etherpad_sd_tag
+  tag etherpad_snowdrift_tag
   port '8086:9001'
   restart_policy 'always'
   env [
     'DB_TYPE=mysql',
-    "DB_HOST=#{db_host}",
-    "DB_NAME=#{etherpad_sd_creds['db_db']}",
-    "DB_USER=#{etherpad_sd_creds['db_user']}",
-    "DB_PASS=#{etherpad_sd_creds['db_passwd']}",
+    "DB_HOST=#{etherpad_snowdrift_db_host}",
+    "DB_NAME=#{etherpad_snowdrift_creds['db_db']}",
+    "DB_USER=#{etherpad_snowdrift_creds['db_user']}",
+    "DB_PASS=#{etherpad_snowdrift_creds['db_passwd']}",
   ]
   sensitive true
 end

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -182,31 +182,48 @@ describe 'osl-app::app3' do
         )
       end
 
-      [
-        %w(etherpad-lite.osuosl.org 8085 osuosl/etherpad),
-        %w(etherpad-snowdrift.osuosl.org 8086 osuosl/etherpad-snowdrift),
-      ].each do |hostname, port, image|
-        it do
-          expect(chef_run).to pull_docker_image(image).with(
-            tag: 'latest'
-          )
-        end
+      it do
+        expect(chef_run).to pull_docker_image('osuosl/etherpad').with(
+          tag: '1.8.6-2020.11.13.2015'
+        )
+      end
 
-        it do
-          expect(chef_run).to run_docker_container(hostname).with(
-            repo: image,
-            tag: 'latest',
-            port: "#{port}:9001",
-            restart_policy: 'always',
-            env: [
-              'DB_TYPE=mysql',
-              'DB_HOST=testdb.osuosl.bak',
-              'DB_NAME=fakedb',
-              'DB_USER=fakeuser',
-              'DB_PASS=fakepw',
-            ]
-          )
-        end
+      it do
+        expect(chef_run).to run_docker_container('etherpad-lite.osuosl.org').with(
+          repo: 'osuosl/etherpad',
+          tag: '1.8.6-2020.11.13.2015',
+          port: '8085:9001',
+          restart_policy: 'always',
+          env: [
+            'DB_TYPE=mysql',
+            'DB_HOST=testdb.osuosl.bak',
+            'DB_NAME=fakedb',
+            'DB_USER=fakeuser',
+            'DB_PASS=fakepw',
+          ]
+        )
+      end
+
+      it do
+        expect(chef_run).to pull_docker_image('osuosl/etherpad-snowdrift').with(
+          tag: '1.8.6-2020.11.13.2015'
+        )
+      end
+
+      it do
+        expect(chef_run).to run_docker_container('etherpad-snowdrift.osuosl.org').with(
+          repo: 'osuosl/etherpad-snowdrift',
+          tag: '1.8.6-2020.11.13.2015',
+          port: '8086:9001',
+          restart_policy: 'always',
+          env: [
+            'DB_TYPE=mysql',
+            'DB_HOST=testdb.osuosl.bak',
+            'DB_NAME=fakedb',
+            'DB_USER=fakeuser',
+            'DB_PASS=fakepw',
+          ]
+        )
       end
     end
   end

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -17,6 +17,15 @@ describe 'osl-app::app3' do
           db_passwd: 'fakepw',
           db_user: 'fakeuser'
         )
+
+        %w(osl snowdrift).each do |type|
+          stub_data_bag_item('etherpad', "mysql_creds_#{type}").and_return(
+            db_db: 'fakedb',
+            db_hostname: 'testdb.osuosl.bak',
+            db_passwd: 'fakepw',
+            db_user: 'fakeuser'
+          )
+        end
       end
 
       %w(staging production).each do |env|
@@ -171,6 +180,33 @@ describe 'osl-app::app3' do
             'REDMINE_PLUGINS_MIGRATE=1',
           ]
         )
+      end
+
+      [
+        %w(etherpad-lite.osuosl.org 8085 osuosl/etherpad),
+        %w(etherpad-snowdrift.osuosl.org 8086 osuosl/etherpad-snowdrift),
+      ].each do |hostname, port, image|
+        it do
+          expect(chef_run).to pull_docker_image(image).with(
+            tag: 'latest'
+          )
+        end
+
+        it do
+          expect(chef_run).to run_docker_container(hostname).with(
+            repo: image,
+            tag: 'latest',
+            port: "#{port}:9001",
+            restart_policy: 'always',
+            env: [
+              'DB_TYPE=mysql',
+              'DB_HOST=testdb.osuosl.bak',
+              'DB_NAME=fakedb',
+              'DB_USER=fakeuser',
+              'DB_PASS=fakepw',
+            ]
+          )
+        end
       end
     end
   end

--- a/test/cookbooks/app_test/recipes/app3.rb
+++ b/test/cookbooks/app_test/recipes/app3.rb
@@ -10,19 +10,27 @@ end
 
 include_recipe 'osl-mysql::server'
 
-percona_mysql_database 'mulgara_redmine' do
-  password 'password'
-  database_name 'mulgara_redmine'
-  action :create
+%w(mulgara_redmine etherpad_osl etherpad_sd).each do |db|
+  percona_mysql_database db do
+    password 'password'
+    database_name db
+    action :create
+  end
 end
 
-percona_mysql_user 'redmine' do
-  database_name 'mulgara_redmine'
-  privileges [:all]
-  password 'passwd'
-  host '172.17.%'
-  ctrl_password 'password'
-  action [:create, :grant]
+[
+  %w(redmine mulgara_redmine),
+  %w(etherpad_osl etherpad_osl),
+  %w(etherpad_sd etherpad_sd),
+].each do |user, db|
+  percona_mysql_user user do
+    database_name db
+    privileges [:all]
+    password 'passwd'
+    host '172.17.%'
+    ctrl_password 'password'
+    action [:create, :grant]
+  end
 end
 
 cookbook_file '/tmp/mulgara_redmine.sql'

--- a/test/integration/app3/inspec/app3_spec.rb
+++ b/test/integration/app3/inspec/app3_spec.rb
@@ -1,26 +1,33 @@
 describe http(
   'http://127.0.0.1/streamwebs-production/media/index.html',
-  headers: { 'Host' => 'streamwebs.org' },
-  enable_remote_worker: true
+  headers: { 'Host' => 'streamwebs.org' }
 ) do
-  its('body') { should match(/^streamwebs-production$/) }
+  its('body') { should match 'streamwebs-production' }
 end
 
 describe http(
   'http://127.0.0.1/streamwebs-staging/media/index.html',
-  headers: { 'Host' => 'streamwebs-staging.osuosl.org' },
-  enable_remote_worker: true
+  headers: { 'Host' => 'streamwebs-staging.osuosl.org' }
 ) do
-  its('body') { should match(/^streamwebs-staging$/) }
+  its('body') { should match 'streamwebs-staging' }
 end
 
 describe http(
   'http://127.0.0.1:8084/',
-  headers: { 'Host' => 'code.mulgara.org' },
-  enable_remote_worker: true
+  headers: { 'Host' => 'code.mulgara.org' }
 ) do
   its('status') { should eq 200 }
-  its('body') { should match(%r{^<title>Mulgara Redmine<\/title>$}) }
+  its('body') { should match '<title>Mulgara Redmine</title>' }
+end
+
+%w(8085 8086).each do |port|
+  describe http(
+    "http://127.0.0.1:#{port}/",
+    headers: { 'Host' => 'etherpad-lite.osuosl.org' }
+  ) do
+    its('status') { should eq 200 }
+    its('body') { should match '<title>Etherpad</title>' }
+  end
 end
 
 %w(streamwebs-production-gunicorn

--- a/test/integration/data_bags/etherpad/mysql_creds_osl.json
+++ b/test/integration/data_bags/etherpad/mysql_creds_osl.json
@@ -1,0 +1,31 @@
+{
+  "id": "mysql_creds_osl",
+  "db_db": {
+    "encrypted_data": "DhxQMA+oh4MTD85j8LRIAiWUVo62nmtPrPSNZs1vaRE=\n",
+    "hmac": "pBHnw4YaX1WEzKOYZjcceHEzqtdr4AuffNPURgC1iXU=\n",
+    "iv": "YHH0mrQ/9KCMj3L2vPkayA==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "db_hostname": {
+    "encrypted_data": "owhY+EGNypGRaFrxaKtjP5JEEesjlWz424fxEDjaC8m4SUVEuBhy/EI6Ggnf\n4kYK\n",
+    "hmac": "/ajGL5G735OrRFBbygskVppuDA+1QuLRn11w1W7fG9g=\n",
+    "iv": "yI4ZmF0TBpCELi/7sT59dg==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "db_user": {
+    "encrypted_data": "2tl51VmlGYYijboJz7S4CYWVDwpDyFyXV1xkMJxV+YM=\n",
+    "hmac": "50rNaR8hrgrF0awyEUbsfftmvjKxr0mjTCc1COQ8bhs=\n",
+    "iv": "MLtcssDHk49NcU3to7SGFA==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "db_passwd": {
+    "encrypted_data": "Jpz+wMNTRgmptHMgoY5PL6rlkKt9m4cDmg4TM+/1RFs=\n",
+    "hmac": "nkEaZ+TNl+HN1284dGdAOoSSiC6K1TNFSRasIhjm1+Q=\n",
+    "iv": "3/r/uHgEzbKZwf05ZmTDZg==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  }
+}

--- a/test/integration/data_bags/etherpad/mysql_creds_snowdrift.json
+++ b/test/integration/data_bags/etherpad/mysql_creds_snowdrift.json
@@ -1,0 +1,31 @@
+{
+  "id": "mysql_creds_snowdrift",
+  "db_db": {
+    "encrypted_data": "+XLmCwO9Un/6Ejf4ZcKx0VSYhXoK9B0bYUDuXhlxhOk=\n",
+    "hmac": "KMRqWfNMnQzQRbU3SWURVYEbDCTJga8sg3snVTQWLD4=\n",
+    "iv": "aR2Px6HuK0gxIvCbFTc3fg==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "db_hostname": {
+    "encrypted_data": "n3+D+6ZKg+D/JY1N6v+h6pKkQX0ZKjuuK9Rt6vqG1mF/2hDdD+KsALKkvx6i\nmbdB\n",
+    "hmac": "icUQFlUeFFd0dM4IPnMZ1v8wF0py2ffEda2NqhEjw4g=\n",
+    "iv": "MTU6QGDn6ldcQLkGCtd7RA==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "db_user": {
+    "encrypted_data": "e0k9OEbAcqm/opqFZ6mgsKEzeZbV31vPqA17C5FkouI=\n",
+    "hmac": "N5WetsuvGONk6EMRbGdUWfVCV83uvPnS0vZSyb6/Gd0=\n",
+    "iv": "RsNzmhtsgZwMJO+fASppDw==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  },
+  "db_passwd": {
+    "encrypted_data": "gZv6JYVVat1wa69mVK+WvsZjeBzECkgAlqwbQFHf+JQ=\n",
+    "hmac": "KWbRelJxHc8y65oi3BNMTgWMqueJTYFnkcoixmX1v4g=\n",
+    "iv": "zxJcxx0uUJn8lTRZ/8whYQ==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  }
+}


### PR DESCRIPTION
Adds `etherpad-lite.osuosl.org` and `etherpad-snowdrift.osuosl.org` docker containers to app3 on ports 8085 and 8086 respectively.

Until `osuosl/etherpad` and `osuosl/etherpad-snowdrift` are published, this can be tested by replacing the images with `etherpad/etherpad`.