### PR TITLE
Set user to etherpad to fix idempotency issues

### DIFF
--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -148,6 +148,7 @@ docker_container 'etherpad-lite.osuosl.org' do
   tag etherpad_osl_tag
   port '8085:9001'
   restart_policy 'always'
+  user 'etherpad'
   env [
     'DB_TYPE=mysql',
     "DB_HOST=#{etherpad_osl_secrets['db_hostname']}",
@@ -173,6 +174,7 @@ docker_container 'etherpad-snowdrift.osuosl.org' do
   tag etherpad_snowdrift_tag
   port '8086:9001'
   restart_policy 'always'
+  user 'etherpad'
   env [
     'DB_TYPE=mysql',
     "DB_HOST=#{etherpad_snowdrift_secrets['db_hostname']}",

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -195,6 +195,7 @@ describe 'osl-app::app3' do
           tag: '1.8.6-2020.11.13.2015',
           port: '8085:9001',
           restart_policy: 'always',
+          user: 'etherpad',
           env: [
             'DB_TYPE=mysql',
             'DB_HOST=testdb.osuosl.bak',
@@ -218,6 +219,7 @@ describe 'osl-app::app3' do
           tag: '1.8.6-2020.11.13.2015',
           port: '8086:9001',
           restart_policy: 'always',
+          user: 'etherpad',
           env: [
             'DB_TYPE=mysql',
             'DB_HOST=testdb.osuosl.bak',


### PR DESCRIPTION
The etherpad container seems to set the user to 'etherpad' by default, but the `docker_container` resource sets it to `''`. Thus on every chef run, it recreates the container which is a problem.

This fixes the issue.
