### PR TITLE
Fix logrotation for openid logs

### DIFF
--- a/recipes/app1.rb
+++ b/recipes/app1.rb
@@ -117,7 +117,7 @@ end
 %w(production staging).each do |type|
   logrotate_app "OpenID-#{type}" do
     path "/home/openid-#{type}/shared/log/*.log"
-    postrotate "/bin/kill -USR1 /home/openid-#{type}/current/tmp/pids/unicorn.pid"
+    postrotate "/bin/kill -USR1 $(cat /home/openid-#{type}/current/tmp/pids/unicorn.pid)"
     frequency 'daily'
     su "openid-#{type} openid-#{type}"
     rotate 30

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -100,7 +100,7 @@ describe 'osl-app::app1' do
           expect(chef_run).to enable_logrotate_app("OpenID-#{type}").with(
             path: "/home/openid-#{type}/shared/log/*.log",
             frequency: 'daily',
-            postrotate: "/bin/kill -USR1 /home/openid-#{type}/current/tmp/pids/unicorn.pid",
+            postrotate: "/bin/kill -USR1 $(cat /home/openid-#{type}/current/tmp/pids/unicorn.pid)",
             su: "openid-#{type} openid-#{type}",
             rotate: 30
           )


### PR DESCRIPTION
We need to tell kill the PID, not just the file...
