### PR TITLE
Create sudoers file based on service_name property

### DIFF
--- a/recipes/app1.rb
+++ b/recipes/app1.rb
@@ -86,14 +86,6 @@ osl_app 'openid-production-delayed-job' do
   reload_cmd '/home/openid-production/.rvm/bin/rvm 2.5.3 do bundle exec bin/delayed_job -n 2 restart'
 end
 
-osl_app 'fenestra' do
-  description 'osuosl dashboard'
-  start_cmd '/home/fenestra/.rvm/bin/rvm 2.2.5 do bundle exec unicorn -l 8082 -c config/unicorn.rb -E deployment -D'
-  working_directory '/home/fenestra/fenestra'
-  pid_file '/home/fenestra/pids/unicorn.pid'
-  action :delete
-end
-
 # Setup logrotate, also make sure that unicorn releases the file handles
 # by sending it a USR1 signal, which will cause it reopen its logs
 %w(production staging).each do |type|

--- a/resources/app.rb
+++ b/resources/app.rb
@@ -19,11 +19,10 @@ property :environment_file, String
 property :verify, [true, false], default: false
 
 action :create do
-  sudo new_resource.user do
+  sudo new_resource.service_name do
     user new_resource.user
     commands osl_sudo_commands(new_resource.service_name)
     nopasswd true
-    action :nothing
   end
 
   systemd_unit "#{new_resource.service_name}.service" do
@@ -49,7 +48,6 @@ action :create do
     }.transform_values(&:compact)) # Remove all keys from the hash that go to nil, these will cause a malformed ini
     action [:create, :enable]
     verify new_resource.verify
-    notifies :create, "sudo[#{new_resource.user}]", :immediately
   end
 end
 

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -78,10 +78,6 @@ describe 'osl-app::app1' do
         )
       end
 
-      it do
-        expect(chef_run).to delete_osl_app('fenestra')
-      end
-
       %w(production staging).each do |type|
         it "should create LogRotate service for OpenID-#{type}" do
           expect(chef_run).to enable_logrotate_app("OpenID-#{type}").with(

--- a/spec/unit/resources/app_spec.rb
+++ b/spec/unit/resources/app_spec.rb
@@ -37,7 +37,7 @@ describe 'osl_app' do
     end
 
     it do
-      is_expected.to nothing_sudo('test_app').with(
+      is_expected.to create_sudo('test_app').with(
         commands: [
           '/usr/bin/systemctl enable test_app',
           '/usr/bin/systemctl disable test_app',
@@ -49,10 +49,6 @@ describe 'osl_app' do
         ],
         nopasswd: true
       )
-    end
-
-    it do
-      expect(subject.systemd_unit('test_app.service')).to notify('sudo[test_app]').to(:create).immediately
     end
   end
 
@@ -127,7 +123,7 @@ describe 'osl_app' do
     end
 
     it do
-      is_expected.to nothing_sudo('testuser').with(
+      is_expected.to create_sudo('test_app').with(
         commands: [
           '/usr/bin/systemctl enable test_app',
           '/usr/bin/systemctl disable test_app',
@@ -139,10 +135,6 @@ describe 'osl_app' do
         ],
         nopasswd: true
       )
-    end
-
-    it do
-      expect(subject.systemd_unit('test_app.service')).to notify('sudo[testuser]').to(:create).immediately
     end
   end
 end

--- a/test/integration/app1/inspec/app1_spec.rb
+++ b/test/integration/app1/inspec/app1_spec.rb
@@ -9,11 +9,12 @@
   end
 end
 
-%w(
-  fenestra
-).each do |s|
-  describe service(s) do
-    it { should_not be_enabled }
-    it { should_not be_running }
-  end
+describe command 'sudo -U openid-production -l' do
+  its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart openid-production-delayed-job} }
+  its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart openid-production-unicorn} }
+end
+
+describe command 'sudo -U openid-staging -l' do
+  its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart openid-staging-delayed-job} }
+  its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart openid-staging-unicorn} }
 end

--- a/test/integration/app2/inspec/app2_spec.rb
+++ b/test/integration/app2/inspec/app2_spec.rb
@@ -50,3 +50,22 @@ describe command('docker exec redmine.replicant.us env') do
     its('stdout') { should match line }
   end
 end
+
+describe command 'sudo -U formsender-staging -l' do
+  its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart formsender-staging-gunicorn} }
+end
+
+describe command 'sudo -U formsender-production -l' do
+  its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart formsender-production-gunicorn} }
+end
+
+%w(
+  iam-production
+  iam-staging
+  timesync-production
+  timesync-staging
+).each do |app|
+  describe command "sudo -U #{app} -l" do
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart #{app}} }
+  end
+end

--- a/test/integration/app3/inspec/app3_spec.rb
+++ b/test/integration/app3/inspec/app3_spec.rb
@@ -109,3 +109,20 @@ end
     its('groups') { should include 'streamwebs-staging' }
   end
 end
+
+describe command 'sudo -U streamwebs-staging -l' do
+  its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart streamwebs-staging-gunicorn} }
+end
+
+describe command 'sudo -U streamwebs-production -l' do
+  its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart streamwebs-production-gunicorn} }
+end
+
+%w(
+  timesync-web-staging
+  timesync-web-production
+).each do |app|
+  describe command "sudo -U #{app} -l" do
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/bin/systemctl restart #{app}} }
+  end
+end


### PR DESCRIPTION
This resolves https://support.osuosl.org/Ticket/Display.html?id=32239

This also removes the notification when creating the sudo as it shouldn't be created and should be created always. In addition, remove the reference to fenestra since it's already been deleted.

Signed-off-by: Lance Albertson <lance@osuosl.org>
