### PR TITLE
Remove server_names_hash_bucket_size as this is now included in osl-nginx

### DIFF
--- a/templates/default/app-nginx.erb
+++ b/templates/default/app-nginx.erb
@@ -1,5 +1,3 @@
-server_names_hash_bucket_size 128;
-
 <% node['osl-app']['nginx'].each do |server_name, data| %>
 
 server {


### PR DESCRIPTION
Signed-off-by: Lance Albertson <lance@osuosl.org>
