### PR TITLE
Add SECRET_KEY_BASE to openid-production-delayed-job

### DIFF
--- a/recipes/app1.rb
+++ b/recipes/app1.rb
@@ -124,6 +124,7 @@ docker_container 'openid-production-delayed-job' do
     'RAILS_ENV=production',
     "DB_PASSWORD=#{openid_secrets['db_password']}",
     "DB_HOST=#{openid_db_host}",
+    "SECRET_KEY_BASE=#{openid_secrets['production']['secret_key_base']}",
   ]
   sensitive true
 end

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -203,6 +203,7 @@ describe 'osl-app::app1' do
             'RAILS_ENV=production',
             'DB_PASSWORD=db_password',
             'DB_HOST=db_host',
+            'SECRET_KEY_BASE=production_secret_key_base',
           ],
           sensitive: true
         )

--- a/test/integration/app1/controls/app1_control.rb
+++ b/test/integration/app1/controls/app1_control.rb
@@ -73,6 +73,10 @@ control 'app1' do
     its('stdout') { should match /SECRET_KEY_BASE=staging_secret_key_base/ }
   end
 
+  describe command('docker exec openid-production-delayed-job env') do
+    its('stdout') { should match /SECRET_KEY_BASE=production_secret_key_base/ }
+  end
+
   describe http 'localhost:8080/foundation/members/registration' do
     its('status') { should cmp 200 }
     its('body') { should match 'Membership Dues' }


### PR DESCRIPTION
- Add SECRET_KEY_BASE env var from production hash to
  openid-production-delayed-job container
- Update unit and integration tests accordingly

https://support.osuosl.org/Ticket/Display.html?id=35332

Signed-off-by: Lance Albertson <lance@osuosl.org>
