### PR TITLE
Add osl_app_dockercompose_wrapper resource and docker wrapper improvements

### DIFF
--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -253,6 +253,10 @@ docker_container 'eec-walkthrough-staging.cass.oregonstate.edu' do
   sensitive true
 end
 
+osl_app_docker_wrapper 'eec-walkthrough-staging.cass.oregonstate.edu' do
+  user 'eec-walkthrough-staging'
+end
+
 # Oregon Invasives Hotline
 invasives_staging = '/home/invasives-staging/oregoninvasiveshotline'
 invasives_secrets = data_bag_item('osl-app', 'invasives')
@@ -340,6 +344,12 @@ osl_dockercompose 'invasives-staging' do
   config_files %w(docker-compose.deploy.yml docker-compose.mailpit.yml)
 end
 
+osl_app_dockercompose_wrapper 'invasives-staging' do
+  directory invasives_staging
+  config_files %w(docker-compose.deploy.yml docker-compose.mailpit.yml)
+  user 'invasives-staging'
+end
+
 # Oregon Invasives Hotline - Production
 invasives_production = '/home/invasives-production/oregoninvasiveshotline'
 invasives_secrets['production']['db_host'] = node['ipaddress'] if node['kitchen']
@@ -422,4 +432,10 @@ end
 osl_dockercompose 'invasives-production' do
   directory invasives_production
   config_files %w(docker-compose.deploy.yml)
+end
+
+osl_app_dockercompose_wrapper 'invasives-production' do
+  directory invasives_production
+  config_files %w(docker-compose.deploy.yml)
+  user 'invasives-production'
 end

--- a/resources/dockercompose_wrapper.rb
+++ b/resources/dockercompose_wrapper.rb
@@ -1,0 +1,46 @@
+provides :osl_app_dockercompose_wrapper
+unified_mode true
+
+default_action :create
+
+property :project_name, String, name_property: true
+property :directory, String, required: true
+property :config_files, Array, default: []
+property :service, String, default: 'app'
+property :command, String, default: 'sh'
+property :user, String, required: true
+
+action :create do
+  config_flags = new_resource.config_files.map { |f| "-f #{f} " }.join
+
+  template "/usr/local/bin/#{new_resource.project_name}-console" do
+    source 'dockercompose-console.erb'
+    cookbook 'osl-app'
+    mode '0750'
+    variables(directory: new_resource.directory, project_name: new_resource.project_name, config_flags: config_flags, service: new_resource.service, command: new_resource.command)
+  end
+
+  template "/usr/local/bin/#{new_resource.project_name}-logs" do
+    source 'dockercompose-logs.erb'
+    cookbook 'osl-app'
+    mode '0750'
+    variables(directory: new_resource.directory, project_name: new_resource.project_name, config_flags: config_flags, service: new_resource.service)
+  end
+
+  template "/usr/local/bin/#{new_resource.project_name}-ps" do
+    source 'dockercompose-ps.erb'
+    cookbook 'osl-app'
+    mode '0750'
+    variables(directory: new_resource.directory, project_name: new_resource.project_name, config_flags: config_flags)
+  end
+
+  sudo new_resource.project_name do
+    user new_resource.user
+    commands [
+      "/usr/local/bin/#{new_resource.project_name}-console",
+      "/usr/local/bin/#{new_resource.project_name}-logs",
+      "/usr/local/bin/#{new_resource.project_name}-ps",
+    ]
+    nopasswd true
+  end
+end

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -426,6 +426,14 @@ describe 'osl-app::app3' do
       end
 
       it do
+        is_expected.to create_osl_app_dockercompose_wrapper('invasives-staging').with(
+          directory: '/home/invasives-staging/oregoninvasiveshotline',
+          config_files: %w(docker-compose.deploy.yml docker-compose.mailpit.yml),
+          user: 'invasives-staging'
+        )
+      end
+
+      it do
         is_expected.to sync_git('/home/invasives-production/oregoninvasiveshotline').with(
           repository: 'https://github.com/osu-cass/oregoninvasiveshotline.git',
           revision: 'main'
@@ -550,6 +558,14 @@ describe 'osl-app::app3' do
         )
       end
 
+      it do
+        is_expected.to create_osl_app_dockercompose_wrapper('invasives-production').with(
+          directory: '/home/invasives-production/oregoninvasiveshotline',
+          config_files: %w(docker-compose.deploy.yml),
+          user: 'invasives-production'
+        )
+      end
+
       # EEC Walkthrough React - Staging
       it do
         is_expected.to pull_docker_image('ghcr.io/osu-cass/eec-walkthrough-react').with(
@@ -630,6 +646,12 @@ describe 'osl-app::app3' do
             '/home/eec-walkthrough-staging/uploads:/app/client/files/uploads',
           ],
           sensitive: true
+        )
+      end
+
+      it do
+        is_expected.to create_osl_app_docker_wrapper('eec-walkthrough-staging.cass.oregonstate.edu').with(
+          user: 'eec-walkthrough-staging'
         )
       end
     end

--- a/spec/unit/resources/docker_wrapper_spec.rb
+++ b/spec/unit/resources/docker_wrapper_spec.rb
@@ -62,4 +62,24 @@ describe 'osl_app_docker_wrapper' do
       nopasswd: true
     )
   end
+
+  it do
+    expect(chef_run).to render_file('/usr/local/bin/test_app-console')
+      .with_content(/usage\(\)/)
+      .with_content(/Open a console on the test_app container/)
+      .with_content(/docker exec -it test_app sh/)
+  end
+
+  it do
+    expect(chef_run).to render_file('/usr/local/bin/test_app_bash-console')
+      .with_content(/Open a console on the test_app_bash container/)
+      .with_content(/docker exec -it test_app_bash bash/)
+  end
+
+  it do
+    expect(chef_run).to render_file('/usr/local/bin/test_app-logs')
+      .with_content(/usage\(\)/)
+      .with_content(/View logs for the test_app container/)
+      .with_content(/docker logs \$\{FOLLOW\} test_app/)
+  end
 end

--- a/spec/unit/resources/dockercompose_wrapper_spec.rb
+++ b/spec/unit/resources/dockercompose_wrapper_spec.rb
@@ -1,0 +1,175 @@
+require_relative '../../spec_helper'
+
+describe 'osl_app_dockercompose_wrapper' do
+  platform 'centos'
+  step_into :osl_app_dockercompose_wrapper
+
+  cached(:subject) { chef_run }
+
+  recipe do
+    osl_app_dockercompose_wrapper 'test_app' do
+      directory '/home/test_app/project'
+      config_files %w(docker-compose.deploy.yml)
+      user 'test_app'
+    end
+
+    osl_app_dockercompose_wrapper 'test_app_custom' do
+      directory '/home/test_app_custom/project'
+      config_files %w(docker-compose.deploy.yml docker-compose.mailpit.yml)
+      service 'web'
+      command 'bash'
+      user 'test_app_custom'
+    end
+  end
+
+  it do
+    is_expected.to create_template('/usr/local/bin/test_app-console').with(
+      source: 'dockercompose-console.erb',
+      cookbook: 'osl-app',
+      mode: '0750',
+      variables: {
+        directory: '/home/test_app/project',
+        project_name: 'test_app',
+        config_flags: '-f docker-compose.deploy.yml ',
+        service: 'app',
+        command: 'sh',
+      }
+    )
+  end
+
+  it do
+    is_expected.to create_template('/usr/local/bin/test_app_custom-console').with(
+      source: 'dockercompose-console.erb',
+      cookbook: 'osl-app',
+      mode: '0750',
+      variables: {
+        directory: '/home/test_app_custom/project',
+        project_name: 'test_app_custom',
+        config_flags: '-f docker-compose.deploy.yml -f docker-compose.mailpit.yml ',
+        service: 'web',
+        command: 'bash',
+      }
+    )
+  end
+
+  it do
+    is_expected.to create_template('/usr/local/bin/test_app-logs').with(
+      source: 'dockercompose-logs.erb',
+      cookbook: 'osl-app',
+      mode: '0750',
+      variables: {
+        directory: '/home/test_app/project',
+        project_name: 'test_app',
+        config_flags: '-f docker-compose.deploy.yml ',
+        service: 'app',
+      }
+    )
+  end
+
+  it do
+    is_expected.to create_template('/usr/local/bin/test_app_custom-logs').with(
+      source: 'dockercompose-logs.erb',
+      cookbook: 'osl-app',
+      mode: '0750',
+      variables: {
+        directory: '/home/test_app_custom/project',
+        project_name: 'test_app_custom',
+        config_flags: '-f docker-compose.deploy.yml -f docker-compose.mailpit.yml ',
+        service: 'web',
+      }
+    )
+  end
+
+  it do
+    is_expected.to create_template('/usr/local/bin/test_app-ps').with(
+      source: 'dockercompose-ps.erb',
+      cookbook: 'osl-app',
+      mode: '0750',
+      variables: {
+        directory: '/home/test_app/project',
+        project_name: 'test_app',
+        config_flags: '-f docker-compose.deploy.yml ',
+      }
+    )
+  end
+
+  it do
+    is_expected.to create_template('/usr/local/bin/test_app_custom-ps').with(
+      source: 'dockercompose-ps.erb',
+      cookbook: 'osl-app',
+      mode: '0750',
+      variables: {
+        directory: '/home/test_app_custom/project',
+        project_name: 'test_app_custom',
+        config_flags: '-f docker-compose.deploy.yml -f docker-compose.mailpit.yml ',
+      }
+    )
+  end
+
+  it do
+    is_expected.to create_sudo('test_app').with(
+      user: %w(test_app),
+      commands: [
+        '/usr/local/bin/test_app-console',
+        '/usr/local/bin/test_app-logs',
+        '/usr/local/bin/test_app-ps',
+      ],
+      nopasswd: true
+    )
+  end
+
+  it do
+    is_expected.to create_sudo('test_app_custom').with(
+      user: %w(test_app_custom),
+      commands: [
+        '/usr/local/bin/test_app_custom-console',
+        '/usr/local/bin/test_app_custom-logs',
+        '/usr/local/bin/test_app_custom-ps',
+      ],
+      nopasswd: true
+    )
+  end
+
+  it do
+    expect(chef_run).to render_file('/usr/local/bin/test_app-console')
+      .with_content(/usage\(\)/)
+      .with_content(/Open a console on a container in the test_app compose project/)
+      .with_content(/SERVICE\s+Service name to exec into \(default: app\)/)
+      .with_content(/docker compose -p test_app -f docker-compose\.deploy\.yml exec \$\{SERVICE\} sh/)
+  end
+
+  it do
+    expect(chef_run).to render_file('/usr/local/bin/test_app_custom-console')
+      .with_content(/Open a console on a container in the test_app_custom compose project/)
+      .with_content(/SERVICE\s+Service name to exec into \(default: web\)/)
+      .with_content(/docker compose -p test_app_custom -f docker-compose\.deploy\.yml -f docker-compose\.mailpit\.yml exec \$\{SERVICE\} bash/)
+  end
+
+  it do
+    expect(chef_run).to render_file('/usr/local/bin/test_app-logs')
+      .with_content(/usage\(\)/)
+      .with_content(/View logs for a container in the test_app compose project/)
+      .with_content(/SERVICE\s+Service name to view logs for \(default: app\)/)
+      .with_content(/docker compose -p test_app -f docker-compose\.deploy\.yml logs \$\{FOLLOW\} \$\{SERVICE\}/)
+  end
+
+  it do
+    expect(chef_run).to render_file('/usr/local/bin/test_app_custom-logs')
+      .with_content(/View logs for a container in the test_app_custom compose project/)
+      .with_content(/SERVICE\s+Service name to view logs for \(default: web\)/)
+      .with_content(/docker compose -p test_app_custom -f docker-compose\.deploy\.yml -f docker-compose\.mailpit\.yml logs \$\{FOLLOW\} \$\{SERVICE\}/)
+  end
+
+  it do
+    expect(chef_run).to render_file('/usr/local/bin/test_app-ps')
+      .with_content(/usage\(\)/)
+      .with_content(/List containers in the test_app compose project/)
+      .with_content(/docker compose -p test_app -f docker-compose\.deploy\.yml ps/)
+  end
+
+  it do
+    expect(chef_run).to render_file('/usr/local/bin/test_app_custom-ps')
+      .with_content(/List containers in the test_app_custom compose project/)
+      .with_content(/docker compose -p test_app_custom -f docker-compose\.deploy\.yml -f docker-compose\.mailpit\.yml ps/)
+  end
+end

--- a/templates/default/docker-console.erb
+++ b/templates/default/docker-console.erb
@@ -1,2 +1,11 @@
 #!/bin/bash
+usage() {
+  echo "Usage: $(basename "$0")"
+  echo
+  echo "Open a console on the <%= @container_name %> container."
+  exit 0
+}
+
+case "${1:-}" in -h|--help) usage ;; esac
+
 /usr/bin/docker exec -it <%= @container_name %> <%= @command %>

--- a/templates/default/docker-logs.erb
+++ b/templates/default/docker-logs.erb
@@ -1,4 +1,16 @@
 #!/bin/bash
+usage() {
+  echo "Usage: $(basename "$0") [-f]"
+  echo
+  echo "View logs for the <%= @container_name %> container."
+  echo
+  echo "Options:"
+  echo "  -f  Follow log output"
+  exit 0
+}
+
+case "${1:-}" in -h|--help) usage ;; esac
+
 FOLLOW=""
 while getopts "f" opt ; do
   case $opt in

--- a/templates/default/dockercompose-console.erb
+++ b/templates/default/dockercompose-console.erb
@@ -1,0 +1,16 @@
+#!/bin/bash
+usage() {
+  echo "Usage: $(basename "$0") [SERVICE]"
+  echo
+  echo "Open a console on a container in the <%= @project_name %> compose project."
+  echo
+  echo "Arguments:"
+  echo "  SERVICE  Service name to exec into (default: <%= @service %>)"
+  exit 0
+}
+
+case "${1:-}" in -h|--help) usage ;; esac
+
+SERVICE="${1:-<%= @service %>}"
+cd <%= @directory %>
+/usr/bin/docker compose -p <%= @project_name %> <%= @config_flags %>exec ${SERVICE} <%= @command %>

--- a/templates/default/dockercompose-logs.erb
+++ b/templates/default/dockercompose-logs.erb
@@ -1,0 +1,31 @@
+#!/bin/bash
+usage() {
+  echo "Usage: $(basename "$0") [-f] [SERVICE]"
+  echo
+  echo "View logs for a container in the <%= @project_name %> compose project."
+  echo
+  echo "Options:"
+  echo "  -f       Follow log output"
+  echo
+  echo "Arguments:"
+  echo "  SERVICE  Service name to view logs for (default: <%= @service %>)"
+  exit 0
+}
+
+case "${1:-}" in -h|--help) usage ;; esac
+
+FOLLOW=""
+while getopts "f" opt ; do
+  case $opt in
+    f)
+      FOLLOW="--follow"
+      ;;
+    *)
+    ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+SERVICE="${1:-<%= @service %>}"
+cd <%= @directory %>
+/usr/bin/docker compose -p <%= @project_name %> <%= @config_flags %>logs ${FOLLOW} ${SERVICE}

--- a/templates/default/dockercompose-ps.erb
+++ b/templates/default/dockercompose-ps.erb
@@ -1,0 +1,12 @@
+#!/bin/bash
+usage() {
+  echo "Usage: $(basename "$0")"
+  echo
+  echo "List containers in the <%= @project_name %> compose project."
+  exit 0
+}
+
+case "${1:-}" in -h|--help) usage ;; esac
+
+cd <%= @directory %>
+/usr/bin/docker compose -p <%= @project_name %> <%= @config_flags %>ps

--- a/test/integration/app3/controls/app3_control.rb
+++ b/test/integration/app3/controls/app3_control.rb
@@ -415,4 +415,81 @@ control 'app3' do
   ) do
     its('status') { should be_in [200, 304] }
   end
+
+  # dockercompose_wrapper - invasives-staging
+  %w(console logs ps).each do |cmd|
+    describe file "/usr/local/bin/invasives-staging-#{cmd}" do
+      it { should exist }
+      it { should be_executable }
+    end
+  end
+
+  describe file '/usr/local/bin/invasives-staging-console' do
+    its('content') { should match /docker compose -p invasives-staging/ }
+    its('content') { should match /exec/ }
+    its('content') { should match /usage\(\)/ }
+  end
+
+  describe file '/usr/local/bin/invasives-staging-logs' do
+    its('content') { should match /docker compose -p invasives-staging/ }
+    its('content') { should match /logs/ }
+    its('content') { should match /usage\(\)/ }
+  end
+
+  describe file '/usr/local/bin/invasives-staging-ps' do
+    its('content') { should match /docker compose -p invasives-staging/ }
+    its('content') { should match /ps/ }
+    its('content') { should match /usage\(\)/ }
+  end
+
+  describe command 'sudo -U invasives-staging -l' do
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/invasives-staging-console} }
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/invasives-staging-logs} }
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/invasives-staging-ps} }
+  end
+
+  # dockercompose_wrapper - invasives-production
+  %w(console logs ps).each do |cmd|
+    describe file "/usr/local/bin/invasives-production-#{cmd}" do
+      it { should exist }
+      it { should be_executable }
+    end
+  end
+
+  describe file '/usr/local/bin/invasives-production-console' do
+    its('content') { should match /docker compose -p invasives-production/ }
+    its('content') { should match /exec/ }
+    its('content') { should match /usage\(\)/ }
+  end
+
+  describe file '/usr/local/bin/invasives-production-logs' do
+    its('content') { should match /docker compose -p invasives-production/ }
+    its('content') { should match /logs/ }
+    its('content') { should match /usage\(\)/ }
+  end
+
+  describe file '/usr/local/bin/invasives-production-ps' do
+    its('content') { should match /docker compose -p invasives-production/ }
+    its('content') { should match /ps/ }
+    its('content') { should match /usage\(\)/ }
+  end
+
+  describe command 'sudo -U invasives-production -l' do
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/invasives-production-console} }
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/invasives-production-logs} }
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/invasives-production-ps} }
+  end
+
+  # docker_wrapper - eec-walkthrough-staging
+  %w(console logs).each do |cmd|
+    describe file "/usr/local/bin/eec-walkthrough-staging.cass.oregonstate.edu-#{cmd}" do
+      it { should exist }
+      it { should be_executable }
+    end
+  end
+
+  describe command 'sudo -U eec-walkthrough-staging -l' do
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/eec-walkthrough-staging.cass.oregonstate.edu-console} }
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/eec-walkthrough-staging.cass.oregonstate.edu-logs} }
+  end
 end


### PR DESCRIPTION
New resource: osl_app_dockercompose_wrapper
- Creates console, logs, and ps wrapper scripts for docker compose projects
- Uses -p flag to target the correct compose project namespace matching osl_dockercompose
- Console and logs scripts accept an optional service argument at runtime
- All scripts support -h/--help for usage information
- Configurable properties: project_name, directory, config_files, service, command, user
- Sudo entries created for all three wrapper scripts

Recipe changes (app3.rb):
- Add osl_app_dockercompose_wrapper for invasives-staging and invasives-production
- Add osl_app_docker_wrapper for eec-walkthrough-staging container

Docker wrapper template improvements:
- Add -h/--help support to docker-console.erb and docker-logs.erb

Tests:
- Add unit tests for dockercompose_wrapper resource with render_file content checks
- Add unit tests for docker_wrapper render_file content including help output
- Add app3_spec tests for all new resource usages
- Add integration tests for wrapper script existence, content, and sudo permissions

Signed-off-by: Lance Albertson <lance@osuosl.org>
