### PR TITLE
Switch etherpad-lite from elestio/etherpad to etherpad/etherpad

### DIFF
--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -146,7 +146,7 @@ end
 etherpad_osl_secrets = data_bag_item('etherpad', 'osl')
 etherpad_osl_secrets['db_hostname'] = node['ipaddress'] if node['kitchen']
 
-docker_image 'elestio/etherpad' do
+docker_image 'etherpad/etherpad' do
   notifies :redeploy, 'docker_container[etherpad-lite.osuosl.org]'
 end
 
@@ -155,7 +155,7 @@ docker_image 'ghcr.io/osuosl/etherpad-snowdrift' do
 end
 
 docker_container 'etherpad-lite.osuosl.org' do
-  repo 'elestio/etherpad'
+  repo 'etherpad/etherpad'
   port '8085:9001'
   restart_policy 'always'
   user 'etherpad'

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -245,13 +245,13 @@ describe 'osl-app::app3' do
       end
 
       it do
-        is_expected.to pull_docker_image('elestio/etherpad').with(
+        is_expected.to pull_docker_image('etherpad/etherpad').with(
           tag: 'latest'
         )
       end
 
       it do
-        expect(chef_run.docker_image('elestio/etherpad')).to \
+        expect(chef_run.docker_image('etherpad/etherpad')).to \
           notify('docker_container[etherpad-lite.osuosl.org]').to(:redeploy)
       end
 
@@ -262,7 +262,7 @@ describe 'osl-app::app3' do
 
       it do
         is_expected.to run_docker_container('etherpad-lite.osuosl.org').with(
-          repo: 'elestio/etherpad',
+          repo: 'etherpad/etherpad',
           tag: 'latest',
           port: '8085:9001',
           restart_policy: 'always',

--- a/test/integration/app3/controls/app3_control.rb
+++ b/test/integration/app3/controls/app3_control.rb
@@ -56,7 +56,7 @@ control 'app3' do
     it { should exist }
   end
 
-  describe docker.images.where { repository == 'elestio/etherpad' && tag == 'latest' } do
+  describe docker.images.where { repository == 'etherpad/etherpad' && tag == 'latest' } do
     it { should exist }
   end
 


### PR DESCRIPTION
- Replace elestio/etherpad with official etherpad/etherpad image
- Fixes 'Cannot find module mysql2' caused by ueberdb2 5.x in elestio rebuild
- Update recipe, spec, and integration tests
