### PR TITLE
Add google_map_id secret for invasives

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: vagrant
-  flavor_ref: 'm2.local.4c4m50d'
+  flavor_ref: 'm2.local.8c8m100d'
 
 verifier:
   name: inspec

--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -333,6 +333,15 @@ file "#{invasives_staging}/docker/secrets/google_api_key.txt" do
   notifies :rebuild, 'osl_dockercompose[invasives-staging]'
 end
 
+file "#{invasives_staging}/docker/secrets/google_map_id.txt" do
+  owner 1000
+  group 1000
+  mode '0400'
+  content invasives_secrets['staging']['google_map_id']
+  sensitive true
+  notifies :rebuild, 'osl_dockercompose[invasives-staging]'
+end
+
 docker_image 'ghcr.io/osu-cass/oregoninvasiveshotline-develop' do
   repo 'ghcr.io/osu-cass/oregoninvasiveshotline'
   tag 'develop'
@@ -419,6 +428,15 @@ file "#{invasives_production}/docker/secrets/google_api_key.txt" do
   group 1000
   mode '0400'
   content invasives_secrets['production']['google_api_key']
+  sensitive true
+  notifies :rebuild, 'osl_dockercompose[invasives-production]'
+end
+
+file "#{invasives_production}/docker/secrets/google_map_id.txt" do
+  owner 1000
+  group 1000
+  mode '0400'
+  content invasives_secrets['production']['google_map_id']
   sensitive true
   notifies :rebuild, 'osl_dockercompose[invasives-production]'
 end

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -70,6 +70,7 @@ describe 'osl-app::app3' do
             db_pass: 'invasives-staging',
             db_host: '127.0.0.1',
             google_api_key: 'google_api_key:',
+            google_map_id: 'google_map_id:',
             mailpit_ui_auth: 'admin:admin',
             secret_key: 'secret_key:',
           },
@@ -79,6 +80,7 @@ describe 'osl-app::app3' do
             db_pass: 'invasives-production',
             db_host: '127.0.0.1',
             google_api_key: 'google_api_key:',
+            google_map_id: 'google_map_id:',
             secret_key: 'secret_key:',
             sentry_dsn: 'sentry_dsn',
           }
@@ -407,6 +409,21 @@ describe 'osl-app::app3' do
       end
 
       it do
+        is_expected.to create_file('/home/invasives-staging/oregoninvasiveshotline/docker/secrets/google_map_id.txt').with(
+          owner: 1000,
+          group: 1000,
+          mode: '0400',
+          content: 'google_map_id:',
+          sensitive: true
+        )
+      end
+
+      it do
+        expect(chef_run.file('/home/invasives-staging/oregoninvasiveshotline/docker/secrets/google_map_id.txt')).to \
+          notify('osl_dockercompose[invasives-staging]').to(:rebuild)
+      end
+
+      it do
         is_expected.to pull_docker_image('ghcr.io/osu-cass/oregoninvasiveshotline-develop').with(
           repo: 'ghcr.io/osu-cass/oregoninvasiveshotline',
           tag: 'develop'
@@ -536,6 +553,21 @@ describe 'osl-app::app3' do
 
       it do
         expect(chef_run.file('/home/invasives-production/oregoninvasiveshotline/docker/secrets/google_api_key.txt')).to \
+          notify('osl_dockercompose[invasives-production]').to(:rebuild)
+      end
+
+      it do
+        is_expected.to create_file('/home/invasives-production/oregoninvasiveshotline/docker/secrets/google_map_id.txt').with(
+          owner: 1000,
+          group: 1000,
+          mode: '0400',
+          content: 'google_map_id:',
+          sensitive: true
+        )
+      end
+
+      it do
+        expect(chef_run.file('/home/invasives-production/oregoninvasiveshotline/docker/secrets/google_map_id.txt')).to \
           notify('osl_dockercompose[invasives-production]').to(:rebuild)
       end
 

--- a/test/integration/app3/controls/app3_control.rb
+++ b/test/integration/app3/controls/app3_control.rb
@@ -203,6 +203,15 @@ control 'app3' do
     its('size') { should eq 0 }
   end
 
+  describe file('/home/invasives-staging/oregoninvasiveshotline/docker/secrets/google_map_id.txt') do
+    it { should exist }
+    it { should be_file }
+    its('mode') { should cmp '0400' }
+    its('uid') { should eq 1000 }
+    its('gid') { should eq 1000 }
+    its('size') { should eq 0 }
+  end
+
   describe docker.images.where { repository == 'ghcr.io/osu-cass/oregoninvasiveshotline' && tag == 'develop' } do
     it { should exist }
   end
@@ -302,6 +311,15 @@ control 'app3' do
   end
 
   describe file('/home/invasives-production/oregoninvasiveshotline/docker/secrets/google_api_key.txt') do
+    it { should exist }
+    it { should be_file }
+    its('mode') { should cmp '0400' }
+    its('uid') { should eq 1000 }
+    its('gid') { should eq 1000 }
+    its('size') { should eq 0 }
+  end
+
+  describe file('/home/invasives-production/oregoninvasiveshotline/docker/secrets/google_map_id.txt') do
     it { should exist }
     it { should be_file }
     its('mode') { should cmp '0400' }

--- a/test/integration/data_bags/osl-app/invasives.json
+++ b/test/integration/data_bags/osl-app/invasives.json
@@ -7,6 +7,7 @@
     "db_host": "127.0.0.1",
     "sentry_dsn": "https://368817c1266fd9015d79b8e5b6f99f73@o23529.ingest.us.sentry.io/4510286887583744",
     "google_api_key": "",
+    "google_map_id": "",
     "secret_key": "+cj5n258ct-lge3=vvr!r0byc-8$+ch7$f9&#g6_kk(uxngmkc"
   },
   "staging": {
@@ -17,6 +18,7 @@
     "mailpit_ui_auth": "admin:admin",
     "sentry_dsn": "https://368817c1266fd9015d79b8e5b6f99f73@o23529.ingest.us.sentry.io/4510286887583744",
     "google_api_key": "",
+    "google_map_id": "",
     "secret_key": "+cj5n258ct-lge3=vvr!r0byc-8$+ch7$f9&#g6_kk(uxngmkc"
   }
 }


### PR DESCRIPTION
- Add google_map_id.txt secret file for both staging and production
- Add unit spec tests and stub data for google_map_id
- Add integration test checks for google_map_id.txt
- Update data bag with google_map_id key
- Increase kitchen VM flavor to m2.local.8c8m100d for more RAM
