### PR TITLE
Add formsender-opf instance and test the PR image

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ supports         'almalinux', '~> 8.0'
 supports         'almalinux', '~> 9.0'
 supports         'almalinux', '~> 10.0'
 
-depends          'htpasswd'
+depends          'htpasswd', '< 2.0.18'
 depends          'osl-docker'
 depends          'osl-firewall'
 depends          'osl-git'

--- a/recipes/app2.rb
+++ b/recipes/app2.rb
@@ -65,6 +65,7 @@ end
 docker_image 'ghcr.io/osuosl/formsender' do
   tag 'master'
   notifies :redeploy, 'docker_container[formsender]'
+  notifies :redeploy, 'docker_container[formsender-opf]'
 end
 
 formsender_env = data_bag_item('osl-app', 'formsender')
@@ -79,6 +80,26 @@ docker_container 'formsender' do
     "RT_TOKEN=#{formsender_env['rt_token']}",
     "RECAPTCHA_SECRET=#{formsender_env['recaptcha_secret']}",
     "SENTRY_URI=#{formsender_env['sentry_uri']}",
+  ]
+  sensitive true
+end
+
+# Second formsender instance for the OpenPower Foundation, pointed at a
+# separate RT instance via RT_URL. Same image as above; the RT user/token,
+# form token, and reCAPTCHA secret all differ and live in their own data bag.
+formsender_opf_env = data_bag_item('osl-app', 'formsender-opf')
+
+docker_container 'formsender-opf' do
+  repo 'ghcr.io/osuosl/formsender'
+  tag 'master'
+  port '8087:5000'
+  restart_policy 'always'
+  env [
+    "RT_URL=#{formsender_opf_env['rt_url']}",
+    "TOKEN=#{formsender_opf_env['token']}",
+    "RT_TOKEN=#{formsender_opf_env['rt_token']}",
+    "RECAPTCHA_SECRET=#{formsender_opf_env['recaptcha_secret']}",
+    "SENTRY_URI=#{formsender_opf_env['sentry_uri']}",
   ]
   sensitive true
 end

--- a/spec/app2_spec.rb
+++ b/spec/app2_spec.rb
@@ -23,6 +23,13 @@ describe 'osl-app::app2' do
           recaptcha_secret: 'fakerecaptcha',
           sentry_uri: 'fakeuri'
         )
+        stub_data_bag_item('osl-app', 'formsender-opf').and_return(
+          rt_url: 'https://rt.example.org/REST/2.0/',
+          token: 'opf_faketoken',
+          rt_token: 'opf_rt_faketoken',
+          recaptcha_secret: 'opf_fakerecaptcha',
+          sentry_uri: 'opf_fakeuri'
+        )
       end
 
       it { is_expected.to login_docker_registry('ghcr.io').with(username: 'gh_user', password: 'gh_password') }
@@ -67,6 +74,16 @@ describe 'osl-app::app2' do
       it { expect(chef_run).to pull_docker_image('ghcr.io/osuosl/formsender').with(tag: 'master') }
 
       it do
+        expect(chef_run.docker_image('ghcr.io/osuosl/formsender')).to \
+          notify('docker_container[formsender]').to(:redeploy)
+      end
+
+      it do
+        expect(chef_run.docker_image('ghcr.io/osuosl/formsender')).to \
+          notify('docker_container[formsender-opf]').to(:redeploy)
+      end
+
+      it do
         expect(chef_run).to run_docker_container('formsender').with(
           repo: 'ghcr.io/osuosl/formsender',
           tag: 'master',
@@ -77,6 +94,23 @@ describe 'osl-app::app2' do
             'RT_TOKEN=rt_faketoken',
             'RECAPTCHA_SECRET=fakerecaptcha',
             'SENTRY_URI=fakeuri',
+          ],
+          sensitive: true
+        )
+      end
+
+      it do
+        expect(chef_run).to run_docker_container('formsender-opf').with(
+          repo: 'ghcr.io/osuosl/formsender',
+          tag: 'master',
+          port: '8087:5000',
+          restart_policy: 'always',
+          env: [
+            'RT_URL=https://rt.example.org/REST/2.0/',
+            'TOKEN=opf_faketoken',
+            'RT_TOKEN=opf_rt_faketoken',
+            'RECAPTCHA_SECRET=opf_fakerecaptcha',
+            'SENTRY_URI=opf_fakeuri',
           ],
           sensitive: true
         )

--- a/test/integration/app2/controls/app2_control.rb
+++ b/test/integration/app2/controls/app2_control.rb
@@ -54,4 +54,15 @@ control 'app2' do
   describe http 'http://127.0.0.1:8085/server-status' do
     its('status') { should eq 200 }
   end
+
+  describe docker_container('formsender-opf') do
+    it { should exist }
+    it { should be_running }
+    its('image') { should eq 'ghcr.io/osuosl/formsender:master' }
+    its('ports') { should eq '0.0.0.0:8087->5000/tcp' }
+  end
+
+  describe http 'http://127.0.0.1:8087/server-status' do
+    its('status') { should eq 200 }
+  end
 end

--- a/test/integration/data_bags/osl-app/formsender-opf.json
+++ b/test/integration/data_bags/osl-app/formsender-opf.json
@@ -1,0 +1,7 @@
+{
+  "rt_url": "",
+  "token": "",
+  "rt_token": "",
+  "recaptcha_secret": "",
+  "sentry_uri": ""
+}


### PR DESCRIPTION
Deploy a second formsender container for the OpenPOWER Foundation,
pointed at a separate RT instance via RT_URL, alongside the existing
osuosl formsender. Both containers share one image and a single
formsender tag.

- New docker_container[formsender-opf] on port 8087, configured from the
  osl-app/formsender-opf data bag (rt_url plus per-instance secrets).
- Cover it in the ChefSpec unit test and the app2 InSpec controls, and
  add the integration-test data bag.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
