### PR TITLE
Add EEC Walkthrough React production instance

### DIFF
--- a/recipes/app3.rb
+++ b/recipes/app3.rb
@@ -197,7 +197,8 @@ end
 eec_secrets = data_bag_item('osl-app', 'eec_walkthrough_staging')
 eec_secrets['db_host'] = node['ipaddress'] if node['kitchen']
 
-docker_image 'ghcr.io/osu-cass/eec-walkthrough-react' do
+docker_image 'eec-walkthrough-react-dev' do
+  repo 'ghcr.io/osu-cass/eec-walkthrough-react'
   tag 'dev'
   notifies :redeploy, 'docker_container[eec-walkthrough-staging.cass.oregonstate.edu]'
 end
@@ -255,6 +256,71 @@ end
 
 osl_app_docker_wrapper 'eec-walkthrough-staging.cass.oregonstate.edu' do
   user 'eec-walkthrough-staging'
+end
+
+# EEC Walkthrough React - Production
+eec_production_secrets = data_bag_item('osl-app', 'eec_walkthrough_production')
+eec_production_secrets['db_host'] = node['ipaddress'] if node['kitchen']
+
+docker_image 'eec-walkthrough-react-main' do
+  repo 'ghcr.io/osu-cass/eec-walkthrough-react'
+  tag 'main'
+  notifies :redeploy, 'docker_container[walkthrough.eec.oregonstate.edu]'
+end
+
+directory '/home/eec-walkthrough-production/secrets' do
+  recursive true
+end
+
+directory '/home/eec-walkthrough-production/uploads' do
+  recursive true
+end
+
+directory '/home/eec-walkthrough-production/public-uploads' do
+  recursive true
+end
+
+file '/home/eec-walkthrough-production/secrets/mysql_password.txt' do
+  mode '0400'
+  content eec_production_secrets['db_passwd']
+  sensitive true
+  notifies :redeploy, 'docker_container[walkthrough.eec.oregonstate.edu]'
+end
+
+file '/home/eec-walkthrough-production/secrets/jwt_secret_key.txt' do
+  mode '0400'
+  content eec_production_secrets['jwt_secret_key']
+  sensitive true
+  notifies :redeploy, 'docker_container[walkthrough.eec.oregonstate.edu]'
+end
+
+docker_container 'walkthrough.eec.oregonstate.edu' do
+  repo 'ghcr.io/osu-cass/eec-walkthrough-react'
+  tag 'main'
+  port ['8092:1111', '8093:2222']
+  restart_policy 'always'
+  env [
+    'API_PORT=1111',
+    'FILE_PORT=2222',
+    'NODE_ENV=production',
+    "MYSQL_DB_NAME=#{eec_production_secrets['db_db']}",
+    "MYSQL_HOST=#{eec_production_secrets['db_host']}",
+    'MYSQL_PORT=3306',
+    "MYSQL_USER=#{eec_production_secrets['db_user']}",
+    'MYSQL_PASSWORD_FILE=/run/secrets/mysql_password',
+    'JWT_SECRET_KEY_FILE=/run/secrets/jwt_secret_key',
+  ]
+  volumes [
+    '/home/eec-walkthrough-production/secrets/mysql_password.txt:/run/secrets/mysql_password:ro',
+    '/home/eec-walkthrough-production/secrets/jwt_secret_key.txt:/run/secrets/jwt_secret_key:ro',
+    '/home/eec-walkthrough-production/uploads:/app/client/files/uploads',
+    '/home/eec-walkthrough-production/public-uploads:/app/client/public/uploads',
+  ]
+  sensitive true
+end
+
+osl_app_docker_wrapper 'walkthrough.eec.oregonstate.edu' do
+  user 'eec-walkthrough-production'
 end
 
 # Oregon Invasives Hotline

--- a/spec/app3_spec.rb
+++ b/spec/app3_spec.rb
@@ -92,6 +92,13 @@ describe 'osl-app::app3' do
           db_host: '127.0.0.1',
           jwt_secret_key: 'staging_jwt_secret'
         )
+        stub_data_bag_item('osl-app', 'eec_walkthrough_production').and_return(
+          db_db: 'eec_walkthrough_production',
+          db_user: 'eec-walkthrough-production',
+          db_passwd: 'eec-walkthrough-production',
+          db_host: '127.0.0.1',
+          jwt_secret_key: 'production_jwt_secret'
+        )
       end
 
       it { is_expected.to login_docker_registry('ghcr.io').with(username: 'gh_user', password: 'gh_password') }
@@ -600,13 +607,14 @@ describe 'osl-app::app3' do
 
       # EEC Walkthrough React - Staging
       it do
-        is_expected.to pull_docker_image('ghcr.io/osu-cass/eec-walkthrough-react').with(
+        is_expected.to pull_docker_image('eec-walkthrough-react-dev').with(
+          repo: 'ghcr.io/osu-cass/eec-walkthrough-react',
           tag: 'dev'
         )
       end
 
       it do
-        expect(chef_run.docker_image('ghcr.io/osu-cass/eec-walkthrough-react')).to \
+        expect(chef_run.docker_image('eec-walkthrough-react-dev')).to \
           notify('docker_container[eec-walkthrough-staging.cass.oregonstate.edu]').to(:redeploy)
       end
 
@@ -684,6 +692,96 @@ describe 'osl-app::app3' do
       it do
         is_expected.to create_osl_app_docker_wrapper('eec-walkthrough-staging.cass.oregonstate.edu').with(
           user: 'eec-walkthrough-staging'
+        )
+      end
+
+      # EEC Walkthrough React - Production
+      it do
+        is_expected.to pull_docker_image('eec-walkthrough-react-main').with(
+          repo: 'ghcr.io/osu-cass/eec-walkthrough-react',
+          tag: 'main'
+        )
+      end
+
+      it do
+        expect(chef_run.docker_image('eec-walkthrough-react-main')).to \
+          notify('docker_container[walkthrough.eec.oregonstate.edu]').to(:redeploy)
+      end
+
+      it do
+        is_expected.to create_directory('/home/eec-walkthrough-production/secrets').with(
+          recursive: true
+        )
+      end
+
+      it do
+        is_expected.to create_directory('/home/eec-walkthrough-production/uploads').with(
+          recursive: true
+        )
+      end
+
+      it do
+        is_expected.to create_directory('/home/eec-walkthrough-production/public-uploads').with(
+          recursive: true
+        )
+      end
+
+      it do
+        is_expected.to create_file('/home/eec-walkthrough-production/secrets/mysql_password.txt').with(
+          mode: '0400',
+          content: 'eec-walkthrough-production',
+          sensitive: true
+        )
+      end
+
+      it do
+        expect(chef_run.file('/home/eec-walkthrough-production/secrets/mysql_password.txt')).to \
+          notify('docker_container[walkthrough.eec.oregonstate.edu]').to(:redeploy)
+      end
+
+      it do
+        is_expected.to create_file('/home/eec-walkthrough-production/secrets/jwt_secret_key.txt').with(
+          mode: '0400',
+          content: 'production_jwt_secret',
+          sensitive: true
+        )
+      end
+
+      it do
+        expect(chef_run.file('/home/eec-walkthrough-production/secrets/jwt_secret_key.txt')).to \
+          notify('docker_container[walkthrough.eec.oregonstate.edu]').to(:redeploy)
+      end
+
+      it do
+        is_expected.to run_docker_container('walkthrough.eec.oregonstate.edu').with(
+          repo: 'ghcr.io/osu-cass/eec-walkthrough-react',
+          tag: 'main',
+          port: ['8092:1111', '8093:2222'],
+          restart_policy: 'always',
+          env: [
+            'API_PORT=1111',
+            'FILE_PORT=2222',
+            'NODE_ENV=production',
+            'MYSQL_DB_NAME=eec_walkthrough_production',
+            'MYSQL_HOST=127.0.0.1',
+            'MYSQL_PORT=3306',
+            'MYSQL_USER=eec-walkthrough-production',
+            'MYSQL_PASSWORD_FILE=/run/secrets/mysql_password',
+            'JWT_SECRET_KEY_FILE=/run/secrets/jwt_secret_key',
+          ],
+          volumes_binds: [
+            '/home/eec-walkthrough-production/public-uploads:/app/client/public/uploads',
+            '/home/eec-walkthrough-production/secrets/jwt_secret_key.txt:/run/secrets/jwt_secret_key:ro',
+            '/home/eec-walkthrough-production/secrets/mysql_password.txt:/run/secrets/mysql_password:ro',
+            '/home/eec-walkthrough-production/uploads:/app/client/files/uploads',
+          ],
+          sensitive: true
+        )
+      end
+
+      it do
+        is_expected.to create_osl_app_docker_wrapper('walkthrough.eec.oregonstate.edu').with(
+          user: 'eec-walkthrough-production'
         )
       end
     end

--- a/test/cookbooks/app_test/recipes/app3.rb
+++ b/test/cookbooks/app_test/recipes/app3.rb
@@ -3,6 +3,7 @@
   %w(etherpad snowdrift),
   %w(mulgara_redmine mysql_creds),
   %w(osl-app eec_walkthrough_staging),
+  %w(osl-app eec_walkthrough_production),
 ].each do |bag, item|
   dbcreds = data_bag_item(bag, item)
   dbcreds['db_hostname'] = '172.%'
@@ -78,6 +79,15 @@ end
 
 execute "mysql -posl_mysql_test eec_walkthrough_staging < #{Chef::Config[:file_cache_path]}/eec_walkthrough.sql && touch /tmp/eec_walkthrough.done" do
   creates '/tmp/eec_walkthrough.done'
+end
+
+remote_file "#{Chef::Config[:file_cache_path]}/eec_walkthrough_production.sql" do
+  source 'https://github.com/osu-cass/eec-walkthrough-react/raw/refs/heads/main/services/database/db-init-new.sql'
+  sensitive true
+end
+
+execute "mysql -posl_mysql_test eec_walkthrough_production < #{Chef::Config[:file_cache_path]}/eec_walkthrough_production.sql && touch /tmp/eec_walkthrough_production.done" do
+  creates '/tmp/eec_walkthrough_production.done'
 end
 
 directory '/data/docker/code.mulgara.org/2019/09' do

--- a/test/integration/app3/controls/app3_control.rb
+++ b/test/integration/app3/controls/app3_control.rb
@@ -434,6 +434,77 @@ control 'app3' do
     its('status') { should be_in [200, 304] }
   end
 
+  # EEC Walkthrough React - Production
+  describe docker.images.where { repository == 'ghcr.io/osu-cass/eec-walkthrough-react' && tag == 'main' } do
+    it { should exist }
+  end
+
+  describe docker_container('walkthrough.eec.oregonstate.edu') do
+    it { should exist }
+    it { should be_running }
+    its('image') { should eq 'ghcr.io/osu-cass/eec-walkthrough-react:main' }
+    its('ports') { should match(/0.0.0.0:8092->1111/) }
+    its('ports') { should match(/0.0.0.0:8093->2222/) }
+  end
+
+  describe directory('/home/eec-walkthrough-production/secrets') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'eec-walkthrough-production' }
+  end
+
+  describe directory('/home/eec-walkthrough-production/uploads') do
+    it { should exist }
+  end
+
+  describe directory('/home/eec-walkthrough-production/public-uploads') do
+    it { should exist }
+  end
+
+  describe file('/home/eec-walkthrough-production/secrets/mysql_password.txt') do
+    it { should exist }
+    it { should be_file }
+    its('mode') { should cmp '0400' }
+    its('content') { should cmp 'eec-walkthrough-production' }
+  end
+
+  describe file('/home/eec-walkthrough-production/secrets/jwt_secret_key.txt') do
+    it { should exist }
+    it { should be_file }
+    its('mode') { should cmp '0400' }
+    its('content') { should cmp 'production_jwt_secret' }
+  end
+
+  describe command('docker exec walkthrough.eec.oregonstate.edu env') do
+    %W(
+      API_PORT=1111
+      FILE_PORT=2222
+      NODE_ENV=production
+      MYSQL_DB_NAME=eec_walkthrough_production
+      MYSQL_HOST=#{interface('eth0').ipv4_address}
+      MYSQL_PORT=3306
+      MYSQL_USER=eec-walkthrough-production
+      MYSQL_PASSWORD_FILE=/run/secrets/mysql_password
+      JWT_SECRET_KEY_FILE=/run/secrets/jwt_secret_key
+    ).each do |line|
+      its('stdout') { should match line }
+    end
+  end
+
+  describe http(
+    'http://127.0.0.1:8093',
+    headers: { 'Host' => 'walkthrough.eec.oregonstate.edu' }
+  ) do
+    its('status') { should eq 200 }
+  end
+
+  describe http(
+    'http://127.0.0.1:8092/api/home',
+    headers: { 'Host' => 'walkthrough.eec.oregonstate.edu' }
+  ) do
+    its('status') { should be_in [200, 304] }
+  end
+
   # dockercompose_wrapper - invasives-staging
   %w(console logs ps).each do |cmd|
     describe file "/usr/local/bin/invasives-staging-#{cmd}" do
@@ -509,5 +580,18 @@ control 'app3' do
   describe command 'sudo -U eec-walkthrough-staging -l' do
     its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/eec-walkthrough-staging.cass.oregonstate.edu-console} }
     its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/eec-walkthrough-staging.cass.oregonstate.edu-logs} }
+  end
+
+  # docker_wrapper - eec-walkthrough-production
+  %w(console logs).each do |cmd|
+    describe file "/usr/local/bin/walkthrough.eec.oregonstate.edu-#{cmd}" do
+      it { should exist }
+      it { should be_executable }
+    end
+  end
+
+  describe command 'sudo -U eec-walkthrough-production -l' do
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/walkthrough.eec.oregonstate.edu-console} }
+    its('stdout') { should match %r{\(ALL\) NOPASSWD: /usr/local/bin/walkthrough.eec.oregonstate.edu-logs} }
   end
 end

--- a/test/integration/data_bags/osl-app/eec_walkthrough_production.json
+++ b/test/integration/data_bags/osl-app/eec_walkthrough_production.json
@@ -1,0 +1,8 @@
+{
+  "id": "eec_walkthrough_production",
+  "db_db": "eec_walkthrough_production",
+  "db_user": "eec-walkthrough-production",
+  "db_passwd": "eec-walkthrough-production",
+  "db_host": "127.0.0.1",
+  "jwt_secret_key": "production_jwt_secret"
+}

--- a/test/integration/data_bags/users/eec-walkthrough-production.json
+++ b/test/integration/data_bags/users/eec-walkthrough-production.json
@@ -1,0 +1,10 @@
+{
+  "id": "eec-walkthrough-production",
+  "username": "eec-walkthrough-production",
+  "ssh_keygen": false,
+  "homedir_mode": "02750",
+  "groups": [
+    "app3"
+  ],
+  "shell": "/bin/bash"
+}


### PR DESCRIPTION
- Deploy walkthrough.eec.oregonstate.edu on ports 8092/8093 from the `main`
  tag, alongside the existing staging instance
- Secrets come from a new osl-app/eec_walkthrough_production data bag; runs
  as the eec-walkthrough-production user
- eec-walkthrough-production.cass.oregonstate.edu points at the same
  instance; the container does not vhost, so both names work as-is
- Rename the staging docker_image to eec-walkthrough-react-dev and add
  eec-walkthrough-react-main, since two tags of the same repo need distinct
  resource names (as with streamwebs-develop/master)
- Add test fixtures and ChefSpec/InSpec coverage for the new instance

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
