### PR TITLE
Add quay.io pull-through cache registry

### DIFF
--- a/recipes/app1.rb
+++ b/recipes/app1.rb
@@ -53,6 +53,7 @@ end
 docker_image 'registry' do
   tag '2'
   notifies :redeploy, 'docker_container[registry.osuosl.org]'
+  notifies :redeploy, 'docker_container[registry-quay]'
 end
 
 docker_container 'openid-staging-website' do
@@ -140,6 +141,7 @@ registry_secrets['htpasswds'].each do |u|
     password u['password']
     type u['type'] if u['type']
     notifies :redeploy, 'docker_container[registry.osuosl.org]'
+    notifies :redeploy, 'docker_container[registry-quay]'
   end
 end
 
@@ -205,6 +207,46 @@ docker_container 'registry.osuosl.org' do
   ]
   volumes ['/usr/local/etc/registry.osuosl.org:/auth']
   port '8082:5000'
+  health_check(
+    'Test' => ['CMD', 'wget', '--spider', '-q', 'http://localhost:5000/v2/'],
+    'Interval' => 30_000_000_000,
+    'Timeout' => 10_000_000_000,
+    'Retries' => 3
+  )
+end
+
+# quay.io pull-through cache. A registry instance can only proxy a single
+# upstream, so this runs alongside the Docker Hub cache and haproxy routes
+# /v2/quay.io/* requests here (stripping the prefix). Shares the S3 bucket
+# under its own root directory so repository paths from the two upstreams
+# can't collide.
+registry_quay_storage_env =
+  if kitchen?
+    registry_storage_env
+  else
+    registry_storage_env + ['REGISTRY_STORAGE_S3_ROOTDIRECTORY=/quay']
+  end
+
+docker_container 'registry-quay' do
+  repo 'registry'
+  tag '2'
+  restart_policy 'always'
+  sensitive true
+  links ['registry-valkey:redis']
+  env registry_quay_storage_env + [
+    # Same Valkey instance as the Docker Hub cache, isolated in its own DB
+    'REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR=redis',
+    'REGISTRY_REDIS_ADDR=redis:6379',
+    'REGISTRY_REDIS_DB=1',
+    # Proxy/mirror configuration
+    'REGISTRY_PROXY_REMOTEURL=https://quay.io',
+    "REGISTRY_PROXY_USERNAME=#{registry_secrets['quay_username']}",
+    "REGISTRY_PROXY_PASSWORD=#{registry_secrets['quay_password']}",
+    # HTTP performance settings
+    'REGISTRY_HTTP_DRAINTIMEOUT=60s',
+  ]
+  volumes ['/usr/local/etc/registry.osuosl.org:/auth']
+  port '8083:5000'
   health_check(
     'Test' => ['CMD', 'wget', '--spider', '-q', 'http://localhost:5000/v2/'],
     'Interval' => 30_000_000_000,

--- a/spec/app1_spec.rb
+++ b/spec/app1_spec.rb
@@ -35,6 +35,8 @@ describe 'osl-app::app1' do
           secret_key: 'secret_key',
           docker_username: 'docker_username',
           docker_password: 'docker_password',
+          quay_username: 'quay_username',
+          quay_password: 'quay_password',
           htpasswds: [
             {
               username: 'guest',
@@ -106,6 +108,11 @@ describe 'osl-app::app1' do
       it do
         expect(chef_run.docker_image('registry')).to \
           notify('docker_container[registry.osuosl.org]').to(:redeploy)
+      end
+
+      it do
+        expect(chef_run.docker_image('registry')).to \
+          notify('docker_container[registry-quay]').to(:redeploy)
       end
 
       it { is_expected.to create_directory('/usr/local/etc/registry.osuosl.org').with(recursive: true) }
@@ -239,6 +246,36 @@ describe 'osl-app::app1' do
             'REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io',
             'REGISTRY_PROXY_USERNAME=docker_username',
             'REGISTRY_PROXY_PASSWORD=docker_password',
+            'REGISTRY_HTTP_DRAINTIMEOUT=60s',
+          ],
+          volumes_binds: ['/usr/local/etc/registry.osuosl.org:/auth'],
+          sensitive: true
+        )
+      end
+
+      it do
+        is_expected.to run_docker_container('registry-quay').with(
+          tag: '2',
+          port: '8083:5000',
+          restart_policy: 'always',
+          links: ['registry-valkey:redis'],
+          env: [
+            'REGISTRY_STORAGE=s3',
+            'REGISTRY_STORAGE_S3_ACCESSKEY=access_key',
+            'REGISTRY_STORAGE_S3_SECRETKEY=secret_key',
+            'REGISTRY_STORAGE_S3_REGION=us-east-1',
+            'REGISTRY_STORAGE_S3_BUCKET=osuosl-registry',
+            'REGISTRY_STORAGE_S3_REGIONENDPOINT=s3.osuosl.org',
+            'REGISTRY_STORAGE_S3_CHUNKSIZE=104857600',
+            'REGISTRY_STORAGE_S3_MULTIPARTCOPYCHUNKSIZE=104857600',
+            'REGISTRY_STORAGE_S3_MULTIPARTCOPYMAXCONCURRENCY=32',
+            'REGISTRY_STORAGE_S3_ROOTDIRECTORY=/quay',
+            'REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR=redis',
+            'REGISTRY_REDIS_ADDR=redis:6379',
+            'REGISTRY_REDIS_DB=1',
+            'REGISTRY_PROXY_REMOTEURL=https://quay.io',
+            'REGISTRY_PROXY_USERNAME=quay_username',
+            'REGISTRY_PROXY_PASSWORD=quay_password',
             'REGISTRY_HTTP_DRAINTIMEOUT=60s',
           ],
           volumes_binds: ['/usr/local/etc/registry.osuosl.org:/auth'],

--- a/test/integration/app1/controls/app1_control.rb
+++ b/test/integration/app1/controls/app1_control.rb
@@ -54,6 +54,12 @@ control 'app1' do
     its('ports') { should match %r{0.0.0.0:8082->5000/tcp} }
   end
 
+  describe docker_container 'registry-quay' do
+    it { should exist }
+    it { should be_running }
+    its('ports') { should match %r{0.0.0.0:8083->5000/tcp} }
+  end
+
   describe file '/usr/local/etc/registry.osuosl.org/htpasswd' do
     its('content') { should match /^guest:\$apr1/ }
     its('content') { should match /^admin:\$apr1/ }

--- a/test/integration/data_bags/osl-app/registry.json
+++ b/test/integration/data_bags/osl-app/registry.json
@@ -4,6 +4,8 @@
   "secret_key": "secret_key",
   "docker_username": "example",
   "docker_password": "example",
+  "quay_username": "example",
+  "quay_password": "example",
   "htpasswds": [
     {
       "username": "guest",


### PR DESCRIPTION
A registry instance can only proxy a single upstream, so run a second
registry container (port 8083) alongside the Docker Hub cache for
quay.io. It shares the Valkey blob descriptor cache in a separate Redis
DB and the S3 bucket under a /quay root directory so repository paths
from the two upstreams can't collide. haproxy routes
registry.osuosl.org/v2/quay.io/* requests to it with the prefix
stripped.

Requires quay_username/quay_password (quay.io robot account) in the
osl-app/registry data bag.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
